### PR TITLE
65 change cli to reflect new usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 VesMod is a Python package for extracting membrane contours from microscopy videos of giant unilamellar vesicles (GUVs) and estimating membrane bending rigidity from thermal shape fluctuations.
 
-The Python API separates image-dependent edge extraction from quality control and downstream fluctuation analysis so extracted contours can be reused under multiple QC configurations.
+VesEdge separates image-dependent edge extraction from quality control so the same extracted contours can be evaluated under multiple QC configurations without rerunning image processing.
 
 ---
 
@@ -17,10 +17,11 @@ Features include:
 * Automated vesicle edge detection
 * Processing of ND2 microscopy videos
 * User-supplied edge extraction algorithms
+* Reusable `.npz` extraction checkpoints
 * Frame-level curvature quality control
 * Trajectory-level center/radius population quality control
-* Reusable `.npz` extraction checkpoints through the Python API
 * Rerunnable QC without repeating edge extraction
+* QC provenance and batch-summary outputs
 * Optional angular downsampling
 * NumPy export of accepted contours
 * Annotated GIF generation for visual inspection
@@ -68,45 +69,99 @@ edgemod --help
 
 ---
 
-## Typical CLI Workflow
+## Recommended CLI Workflow
 
-### 1. Extract, QC, and save accepted contours
+VesEdge uses two explicit stages:
+
+```text
+ND2 videos
+   │
+   │ vesedge extract
+   ▼
+QC-independent .npz checkpoints
+   │
+   ├── vesedge qc, configuration A ──▶ accepted .npy files
+   ├── vesedge qc, configuration B ──▶ accepted .npy files
+   └── vesedge qc, configuration C ──▶ accepted .npy files
+                                            │
+                                            ▼
+                                         EdgeMod
+```
+
+Extract each microscopy video once and keep the resulting checkpoint. QC can then be rerun repeatedly without invoking the edge extractor again.
+
+### 1. Extract videos to checkpoints
 
 ```bash
-vesedge sample.nd2 \
+vesedge extract ./videos \
     --pixels-per-micron 13.44 \
     --downsample \
-    --n-samples 120
+    --n-samples 120 \
+    --output-dir ./checkpoints
 ```
 
-This generates:
+This creates one `.npz` checkpoint per input video and, unless `--no-gif` is used, a GIF showing the extracted contours.
 
 ```text
-sample.npy
-sample.gif
+checkpoints/
+├── sample01.npz
+├── sample01.gif
+├── sample02.npz
+└── sample02.gif
 ```
 
-The `.npy` file contains only contours accepted by the configured VesEdge QC checks and is ready for EdgeMod.
+The checkpoint contains extraction state only. It does not store QC decisions.
 
-### 2. Estimate membrane mechanical properties
+### 2. Apply a QC configuration
+
+Use a separate output directory for each QC configuration:
 
 ```bash
-edgemod sample.npy
+vesedge qc ./checkpoints \
+    --curvature-threshold 5 \
+    --population-bic-threshold 10 \
+    --max-minor-population-fraction 0.25 \
+    --output-dir ./results/qc_standard
 ```
 
-This generates:
+This creates:
 
 ```text
-sample.json
+results/qc_standard/
+├── sample01.npy
+├── sample02.npy
+├── vesedge_qc.json
+└── qc_summary.csv
 ```
 
-containing fitted membrane mechanical parameters.
+`vesedge_qc.json` records the exact QC configuration and input path. `qc_summary.csv` reports extraction failures, curvature rejections, population rejections, accepted-frame counts, and accepted fractions for each checkpoint.
+
+### 3. Compare alternate QC configurations
+
+For example:
+
+```bash
+vesedge qc ./checkpoints \
+    --curvature-threshold 10 \
+    --output-dir ./results/qc_permissive
+```
+
+Keeping each QC configuration in its own directory makes the analysis provenance explicit and allows the outputs to be compared directly.
+
+### 4. Analyze each QC result with EdgeMod
+
+```bash
+edgemod ./results/qc_standard
+edgemod ./results/qc_permissive
+```
+
+The resulting EdgeMod outputs can then be compared together with each directory's `vesedge_qc.json` and `qc_summary.csv` when reporting how sensitive the result is to QC choices.
 
 ---
 
-## Reusing Extraction Results in Python
+## Equivalent Python Workflow
 
-The refactored API separates raw video data from extracted-edge state:
+The Python API exposes the same separation:
 
 ```python
 from vesmod.VesEdge import (
@@ -125,15 +180,11 @@ edges = video.extract_edges(
         n_angular_samples=120,
     ),
 )
-```
 
-Save QC-independent extraction state:
-
-```python
 edges.save_checkpoint("sample.npz")
 ```
 
-Reload it later and apply a QC configuration without rerunning extraction:
+Reload the checkpoint and apply QC later:
 
 ```python
 edges = VesicleEdges.from_checkpoint("sample.npz")
@@ -148,9 +199,7 @@ edges.run_qc(qc_config)
 edges.save_edge_to_npy("sample.npy")
 ```
 
-After a completed QC run, `edges.qc_result` contains the configuration and the results from each enabled QC stage. `edges.qc_result.curvature` summarizes curvature scores and rejections, while `edges.qc_result.population` contains the center/radius population-analysis result. Per-detection QC annotations remain available on each `EdgeDetection.qc`.
-
-The same `VesicleEdges` object can be re-QCed with different settings. Checkpoints store extraction state only; QC decisions and `qc_result` are derived and reset on each `run_qc()` call.
+After a completed QC run, `edges.qc_result` contains the configuration and results from the enabled QC stages. Per-detection QC annotations remain available on each `EdgeDetection.qc`.
 
 ---
 
@@ -158,9 +207,11 @@ The same `VesicleEdges` object can be re-QCed with different settings. Checkpoin
 
 | File | Meaning |
 | --- | --- |
-| `.npz` | Reusable, QC-independent VesEdge extraction checkpoint created through the Python API |
-| `.npy` | Accepted contour radii for one QC configuration |
-| `.gif` | Visual inspection of image frames and extracted contours |
+| `.npz` | Reusable, QC-independent VesEdge extraction checkpoint |
+| `.gif` | Visual inspection of raw image frames with extracted contours |
+| `.npy` | Accepted contour radii for one QC configuration, ready for EdgeMod |
+| `vesedge_qc.json` | QC configuration and source path for one QC batch |
+| `qc_summary.csv` | Per-video QC counts and accepted fractions for one QC batch |
 | `.json` | EdgeMod spectrum/fitting output |
 
 ---

--- a/docs/EdgeMod_CLI_README.md
+++ b/docs/EdgeMod_CLI_README.md
@@ -47,13 +47,22 @@ This performs a fit using the default fitting parameters and writes:
 sample.json
 ```
 
+For a VesEdge batch, the recommended input is a QC output directory:
+
+```bash
+vesedge qc ./checkpoints --output-dir ./results/qc_standard
+edgemod ./results/qc_standard
+```
+
+EdgeMod processes the `.npy` files in that directory and ignores the VesEdge provenance files `vesedge_qc.json` and `qc_summary.csv`.
+
 ---
 
 ## Input Requirements
 
 EdgeMod operates on vesicle contour arrays stored in NumPy `.npy` files.
 
-The recommended input is a contour file produced by VesEdge:
+The recommended input is a contour file produced by `vesedge qc`:
 
 ```text
 sample.npy
@@ -85,10 +94,9 @@ print(edges.shape)
 
 In this example, the file contains 250 accepted contours, each sampled at 120 angular positions.
 
-Distances should be stored in microns.
+Distances should be stored in microns. VesEdge `.npy` output contains only contours that passed the selected QC configuration and is directly suitable as EdgeMod CLI input.
 
-VesEdge `.npy` output contains only contours that passed its enabled
-quality-control checks and is directly suitable as EdgeMod CLI input.
+When comparing QC configurations, keep each set of `.npy` files in its own directory and run EdgeMod separately on each directory. The corresponding `vesedge_qc.json` and `qc_summary.csv` files document which QC settings produced each analysis input.
 
 ---
 
@@ -258,13 +266,7 @@ EdgeMod writes:
 sample.json
 ```
 
----
-
 ### JSON Output
-
-```text
-sample.json
-```
 
 The JSON file contains the spectrum metadata and fitted membrane mechanical parameters.
 
@@ -289,10 +291,25 @@ The exact fields may vary depending on the fitting options used and the version 
 edgemod sample.npy
 ```
 
-### Analyze every vesicle in a directory
+### Analyze every vesicle in one VesEdge QC result
 
 ```bash
-edgemod ./edges
+edgemod ./results/qc_standard
+```
+
+### Compare two VesEdge QC configurations
+
+```bash
+vesedge qc ./checkpoints \
+    --curvature-threshold 5 \
+    --output-dir ./results/qc_strict
+
+vesedge qc ./checkpoints \
+    --curvature-threshold 15 \
+    --output-dir ./results/qc_permissive
+
+edgemod ./results/qc_strict
+edgemod ./results/qc_permissive
 ```
 
 ### Analyze an entire directory tree
@@ -330,16 +347,13 @@ edgemod sample.npy --fixed-sigma
 Check that:
 
 * the input path exists
+* `vesedge qc` produced at least one accepted trajectory
 * the files have the `.npy` extension
 * `--recursive` is used if the files are located in subdirectories
-
----
 
 ### `Expected a .npy file`
 
 This occurs when `INPUT_PATH` is a file, but its suffix is not `.npy`.
-
----
 
 ### Fits produce unexpected values
 
@@ -349,8 +363,9 @@ Potential causes include:
 * an inappropriate Fourier fitting range
 * too few accepted contour measurements
 * temperature values inconsistent with the experiment
+* sensitivity of the result to the selected VesEdge QC configuration
 
-Inspect the contour data and consider adjusting:
+Inspect the contour data and `qc_summary.csv`, compare alternate QC configurations when appropriate, and consider adjusting:
 
 ```text
 --lower-fitting-bound

--- a/docs/VesEdge_CLI_README.md
+++ b/docs/VesEdge_CLI_README.md
@@ -1,101 +1,138 @@
 # VesEdge CLI
 
-The VesEdge CLI extracts vesicle contours from ND2 microscopy videos, applies the configured quality-control checks, and writes QC-filtered `.npy` files for EdgeMod. The underlying Python API now separates raw video data, extracted-edge state, and QC so extraction results can also be checkpointed and re-evaluated without rerunning image processing.
+The VesEdge CLI separates image-dependent edge extraction from quality control.
+
+The intended workflow is:
+
+```text
+.nd2 microscopy videos
+        │
+        │ vesedge extract
+        ▼
+QC-independent .npz checkpoints
+        │
+        ├── vesedge qc with configuration A ──▶ filtered .npy files
+        ├── vesedge qc with configuration B ──▶ filtered .npy files
+        └── vesedge qc with configuration C ──▶ filtered .npy files
+                                                     │
+                                                     ▼
+                                                  EdgeMod
+```
+
+This allows expensive image processing to be run once while QC settings are evaluated repeatedly and reproducibly.
 
 ## Quick Start
 
+Extract a directory of ND2 videos:
+
 ```bash
-vesedge sample.nd2 --pixels-per-micron 13.44 --downsample --n-samples 120
+vesedge extract ./videos \
+    --pixels-per-micron 13.44 \
+    --downsample \
+    --n-samples 120 \
+    --output-dir ./checkpoints
 ```
 
-By default this writes:
+Apply one QC configuration:
 
-```text
-sample.npy
-sample.gif
+```bash
+vesedge qc ./checkpoints \
+    --curvature-threshold 5 \
+    --population-bic-threshold 10 \
+    --max-minor-population-fraction 0.25 \
+    --output-dir ./results/qc_standard
 ```
 
-The `.npy` file contains only contours accepted by the configured QC checks, with radii in microns. The GIF overlays extracted contours on the original frames.
+Analyze the filtered results:
+
+```bash
+edgemod ./results/qc_standard
+```
 
 ---
+
+# `vesedge extract`
+
+`vesedge extract` reads ND2 microscopy videos and writes reusable VesEdge `.npz` checkpoints. It does **not** run quality control.
 
 ## Input Selection
 
-Process one ND2 file:
+Extract one video:
 
 ```bash
-vesedge sample.nd2
+vesedge extract sample.nd2
 ```
 
-Process all ND2 files in a directory:
+Extract all ND2 files in a directory:
 
 ```bash
-vesedge ./videos
+vesedge extract ./videos
 ```
 
-Search subdirectories recursively:
+Search recursively:
 
 ```bash
-vesedge ./videos --recursive
+vesedge extract ./videos --recursive
 ```
 
----
+## Output Location
+
+By default, `.npz` and GIF outputs are written beside each ND2 input.
+
+Use a dedicated checkpoint directory with:
+
+```bash
+vesedge extract ./videos --output-dir ./checkpoints
+```
+
+For a file named `sample.nd2`, extraction normally produces:
+
+```text
+sample.npz
+sample.gif
+```
+
+The `.npz` file is the reusable extraction product. It contains successful detections, extraction failures, frame ordering, pixel-space native and analysis contours, and the extraction configuration. It contains no QC decisions.
+
+The GIF overlays the extracted full contour on the original image frames for visual inspection.
+
+Disable GIF creation with:
+
+```bash
+vesedge extract sample.nd2 --no-gif
+```
+
+Existing outputs are not overwritten unless:
+
+```bash
+vesedge extract sample.nd2 --overwrite
+```
 
 ## Microscope Calibration
 
-### `--pixels-per-micron`
-
 ```bash
-vesedge sample.nd2 --pixels-per-micron 13.44
+vesedge extract sample.nd2 --pixels-per-micron 13.44
 ```
 
-Specifies the microscope calibration used when accepted analysis contours are converted from pixels to microns for `.npy` output.
+`--pixels-per-micron` stores the microscope calibration in the checkpoint. Accepted contours are converted from pixels to microns later, when QC output is exported to `.npy`.
 
 Default: `1.0`.
 
----
-
 ## Angular Sampling
 
-Use `--downsample` to resample successful contours to a fixed angular grid before QC and downstream analysis:
+Use fixed angular sampling with:
 
 ```bash
-vesedge sample.nd2 --downsample --n-samples 120
+vesedge extract sample.nd2 --downsample --n-samples 120
 ```
 
-`--n-samples` defaults to `120`. Without `--downsample`, the native angular sampling returned by the extractor is retained, and successful detections must have consistent analysis-contour lengths.
+`--n-samples` defaults to `120` and is used only when `--downsample` is provided.
 
----
-
-## Quality Control
-
-### Curvature QC
-
-```bash
-vesedge sample.nd2 --curvature-threshold 5
-```
-
-`--curvature-threshold` sets the maximum allowed wrapped finite second difference of an analysis contour. Default: `5`.
-
-### Population QC
-
-```bash
-vesedge sample.nd2 \
-    --population-bic-threshold 10 \
-    --max-minor-population-fraction 0.25
-```
-
-Population QC compares frame centers and median radii across the trajectory and can reject a sufficiently small, distinct population. Disable it with:
-
-```bash
-vesedge sample.nd2 --no-population-qc
-```
-
----
+Without `--downsample`, the extractor's native angular sampling is retained as the analysis contour. Successful detections must therefore have consistent analysis-contour lengths.
 
 ## Extraction Algorithm
 
-By default VesEdge uses:
+The default extractor is:
 
 ```text
 vesmod.VesEdge:extract_edge_from_frame
@@ -104,45 +141,185 @@ vesmod.VesEdge:extract_edge_from_frame
 Use an importable custom extractor with:
 
 ```bash
-vesedge sample.nd2 --extractor my_package.my_module:my_edge_extractor
+vesedge extract sample.nd2 \
+    --extractor my_package.my_module:my_edge_extractor
 ```
 
-or a function from a Python file with:
+or a Python source file with:
 
 ```bash
-vesedge sample.nd2 \
+vesedge extract sample.nd2 \
     --extractor-file ./my_extractor.py \
     --extractor-name my_edge_extractor
 ```
 
-See `custom_edge_extraction_algorithms.README.md` for the required interface.
+See `custom_edge_extraction_algorithms.README.md` for the required extractor interface.
 
 ---
 
-## GIF and Existing Outputs
+# `vesedge qc`
 
-Disable GIF output with:
+`vesedge qc` loads one or more VesEdge `.npz` checkpoints, applies a single QC configuration, and writes the accepted contours as `.npy` files for EdgeMod.
 
-```bash
-vesedge sample.nd2 --no-gif
-```
-
-By default an input is skipped if an expected `.npy` or GIF output already exists. Force reprocessing with:
+The command requires an output directory:
 
 ```bash
-vesedge sample.nd2 --overwrite
+vesedge qc ./checkpoints --output-dir ./results/qc_standard
 ```
+
+Use a **different output directory for each QC configuration**. This keeps the `.npy` data, exact QC settings, and QC summary together as one reproducible analysis condition.
+
+## Input Selection
+
+QC one checkpoint:
+
+```bash
+vesedge qc sample.npz --output-dir ./results/qc_standard
+```
+
+QC all checkpoints in a directory:
+
+```bash
+vesedge qc ./checkpoints --output-dir ./results/qc_standard
+```
+
+Search recursively with:
+
+```bash
+vesedge qc ./checkpoints --recursive --output-dir ./results/qc_standard
+```
+
+## Curvature QC
+
+```bash
+vesedge qc ./checkpoints \
+    --curvature-threshold 5 \
+    --output-dir ./results/qc_standard
+```
+
+The curvature threshold is the maximum allowed wrapped finite second difference of an analysis contour.
+
+Default: `5.0`.
+
+Disable curvature QC with:
+
+```bash
+vesedge qc ./checkpoints \
+    --no-curvature-qc \
+    --output-dir ./results/no_curvature
+```
+
+## Population QC
+
+```bash
+vesedge qc ./checkpoints \
+    --population-bic-threshold 10 \
+    --max-minor-population-fraction 0.25 \
+    --output-dir ./results/qc_standard
+```
+
+Population QC compares each successful detection's vesicle center and median analysis radius across the trajectory. A two-component Gaussian-mixture model is used only when enough usable detections are available.
+
+Disable population QC with:
+
+```bash
+vesedge qc ./checkpoints \
+    --no-population-qc \
+    --output-dir ./results/no_population
+```
+
+## QC Outputs
+
+For checkpoints `sample01.npz` and `sample02.npz`, the command:
+
+```bash
+vesedge qc ./checkpoints --output-dir ./results/qc_standard
+```
+
+creates:
+
+```text
+results/qc_standard/
+├── sample01.npy
+├── sample02.npy
+├── vesedge_qc.json
+└── qc_summary.csv
+```
+
+### Filtered `.npy` files
+
+Each `.npy` contains only contours accepted under the current QC configuration, with radial distances converted to microns. These files are directly consumable by EdgeMod.
+
+If a checkpoint completes QC but no frames are accepted, no `.npy` is written for that checkpoint. The failure is still represented in `qc_summary.csv`.
+
+### `vesedge_qc.json`
+
+This file records:
+
+- the checkpoint input path;
+- `curvature_threshold`;
+- `population_bic_threshold`;
+- `max_minor_population_fraction`;
+- whether curvature QC was enabled;
+- whether population QC was enabled.
+
+If an output directory already contains a different QC configuration or input path, VesEdge refuses to mix the results unless `--overwrite` is explicitly supplied.
+
+### `qc_summary.csv`
+
+The summary contains one row per successfully loaded checkpoint with:
+
+- total source frames;
+- successful edge detections;
+- extraction failures;
+- curvature rejections;
+- population rejections;
+- accepted frames;
+- accepted fraction;
+- QC status;
+- any QC error message.
+
+This file is intended to make it easy to compare how aggressive different QC configurations are before comparing the downstream EdgeMod results.
+
+## Comparing QC Configurations
+
+A typical sensitivity analysis might use:
+
+```bash
+vesedge qc ./checkpoints \
+    --curvature-threshold 5 \
+    --output-dir ./results/qc_strict
+
+vesedge qc ./checkpoints \
+    --curvature-threshold 10 \
+    --output-dir ./results/qc_standard
+
+vesedge qc ./checkpoints \
+    --curvature-threshold 15 \
+    --output-dir ./results/qc_permissive
+```
+
+Then run:
+
+```bash
+edgemod ./results/qc_strict
+edgemod ./results/qc_standard
+edgemod ./results/qc_permissive
+```
+
+The resulting EdgeMod estimates can be reported alongside each directory's `vesedge_qc.json` and `qc_summary.csv` to show whether the scientific conclusion depends strongly on QC choices.
 
 ---
 
-## Python API: Separate Extraction and QC
+## Python API
 
-The Python data model separates raw frames from reusable extraction results:
+The CLI mirrors the Python API separation:
 
 ```python
 from vesmod.VesEdge import (
     EdgeExtractionConfig,
     EdgeQCConfig,
+    VesicleEdges,
     VesicleVideo,
     extract_edge_from_frame,
 )
@@ -155,72 +332,44 @@ edges = video.extract_edges(
         n_angular_samples=120,
     ),
 )
-```
-
-`VesicleVideo.extract_edges()` performs extraction only and returns a `VesicleEdges` object. QC is explicit:
-
-```python
-qc_config = EdgeQCConfig(
-    curvature_threshold=10.0,
-    population_bic_threshold=10.0,
-    max_minor_population_fraction=0.25,
-)
-
-edges.run_qc(qc_config)
-edges.save_edge_to_npy("sample.npy")
-```
-
-A completed run is summarized by `edges.qc_result`, a `VesicleQCResult` containing the configuration and the results of each enabled QC stage. Curvature results are available through `edges.qc_result.curvature`, and population-analysis results through `edges.qc_result.population`. Individual detections retain their own detailed QC annotations in `EdgeDetection.qc`.
-
-Calling `run_qc()` again clears the prior derived QC state and aggregate result before applying the new configuration.
-
----
-
-## Checkpointing Extraction Results
-
-The Python API can save QC-independent extraction state:
-
-```python
 edges.save_checkpoint("sample.npz")
 ```
 
-and restore it later:
+Later:
 
 ```python
-from vesmod.VesEdge import VesicleEdges
-
 edges = VesicleEdges.from_checkpoint("sample.npz")
+edges.run_qc(
+    EdgeQCConfig(
+        curvature_threshold=10.0,
+        population_bic_threshold=10.0,
+        max_minor_population_fraction=0.25,
+    )
+)
+edges.save_edge_to_npy("sample.npy")
 ```
 
-A checkpoint stores the extraction configuration, successful native and analysis contours, extraction failures, and frame ordering. QC settings and QC results are intentionally not stored. Physical radii are derived from the stored pixel-space analysis contours and `pixels_per_micron` calibration.
-
-This makes it possible to evaluate several QC configurations without rerunning edge extraction:
-
-```python
-edges.run_qc(qc_config_a)
-edges.save_edge_to_npy("qc_a/sample.npy")
-
-edges.run_qc(qc_config_b)
-edges.save_edge_to_npy("qc_b/sample.npy")
-```
-
-A future CLI update will expose this checkpoint/re-QC workflow directly from the command line. In this PR, the existing CLI continues to perform extraction, QC, and `.npy` export in one invocation.
+A completed run is summarized by `edges.qc_result`; individual detections retain detailed QC annotations through `EdgeDetection.qc`.
 
 ---
 
 ## Troubleshooting
 
-### No successful detections
+### No successful detections during extraction
 
-If extraction fails on every frame, VesEdge reports the per-frame extractor errors and does not continue to QC.
+If extraction fails on every frame, VesEdge reports the extractor errors and does not produce a checkpoint.
 
 ### Inconsistent angular sample counts
 
-If downsampling is disabled, successful detections must use consistent analysis-contour lengths. Enable `--downsample` or modify the extractor to return consistent sampling.
+If downsampling is disabled, successful detections must have consistent analysis-contour lengths. Enable `--downsample` or modify the extractor to return consistent sampling.
 
 ### No frames pass QC
 
-This is distinct from extraction failure: the extractor produced usable contours, but the selected QC configuration rejected all successful detections.
+This is distinct from extraction failure. The checkpoint remains valid, but the selected QC configuration accepted no frames. The event is recorded in `qc_summary.csv` and no `.npy` is written for that checkpoint.
+
+### QC output directory already contains another configuration
+
+Choose another `--output-dir`. Reusing one directory for multiple QC configurations makes provenance ambiguous and is intentionally blocked unless `--overwrite` is used.
 
 ---
 

--- a/docs/VesEdge_CLI_README.md
+++ b/docs/VesEdge_CLI_README.md
@@ -75,6 +75,8 @@ Search recursively:
 vesedge extract ./videos --recursive
 ```
 
+Directory discovery treats file suffixes case-insensitively, so `.nd2` and `.ND2` inputs are handled consistently.
+
 ## Output Location
 
 By default, `.npz` and GIF outputs are written beside each ND2 input.
@@ -92,6 +94,8 @@ sample.npz
 sample.gif
 ```
 
+When recursive input discovery is used with `--output-dir`, VesEdge preserves each input file's path relative to the selected input directory. For example, `videos/a/sample.nd2` and `videos/b/sample.nd2` produce `checkpoints/a/sample.npz` and `checkpoints/b/sample.npz` rather than colliding.
+
 The `.npz` file is the reusable extraction product. It contains successful detections, extraction failures, frame ordering, pixel-space native and analysis contours, and the extraction configuration. It contains no QC decisions.
 
 The GIF overlays the extracted full contour on the original image frames for visual inspection.
@@ -102,7 +106,7 @@ Disable GIF creation with:
 vesedge extract sample.nd2 --no-gif
 ```
 
-Existing outputs are not overwritten unless:
+Existing checkpoints are not overwritten unless:
 
 ```bash
 vesedge extract sample.nd2 --overwrite
@@ -167,7 +171,7 @@ The command requires an output directory:
 vesedge qc ./checkpoints --output-dir ./results/qc_standard
 ```
 
-Use a **different output directory for each QC configuration**. This keeps the `.npy` data, exact QC settings, and QC summary together as one reproducible analysis condition.
+Use a **different output directory for each QC configuration**. This keeps the `.npy` data, exact QC settings, resolved checkpoint selection, and QC summary together as one reproducible analysis condition.
 
 ## Input Selection
 
@@ -188,6 +192,8 @@ Search recursively with:
 ```bash
 vesedge qc ./checkpoints --recursive --output-dir ./results/qc_standard
 ```
+
+Directory discovery treats `.npz` suffixes case-insensitively. For recursive directory inputs, output `.npy` files preserve the checkpoint paths relative to the selected checkpoint directory, preventing equal filenames in different subdirectories from colliding.
 
 ## Curvature QC
 
@@ -250,24 +256,28 @@ results/qc_standard/
 
 Each `.npy` contains only contours accepted under the current QC configuration, with radial distances converted to microns. These files are directly consumable by EdgeMod.
 
-If a checkpoint completes QC but no frames are accepted, no `.npy` is written for that checkpoint. The failure is still represented in `qc_summary.csv`.
+If a checkpoint completes QC but no frames are accepted, no `.npy` is written for that checkpoint. The outcome is still represented in `qc_summary.csv`.
 
 ### `vesedge_qc.json`
 
 This file records:
 
-- the checkpoint input path;
+- the resolved checkpoint input path;
+- whether recursive discovery was enabled;
+- the resolved manifest of checkpoints selected for the batch;
 - `curvature_threshold`;
 - `population_bic_threshold`;
 - `max_minor_population_fraction`;
 - whether curvature QC was enabled;
 - whether population QC was enabled.
 
-If an output directory already contains a different QC configuration or input path, VesEdge refuses to mix the results unless `--overwrite` is explicitly supplied.
+Consequently, recursive and non-recursive runs, or runs resolving to different checkpoint sets, have different provenance even if their QC thresholds are identical.
+
+If an output directory already contains incompatible provenance, VesEdge refuses to mix the results unless `--overwrite` is explicitly supplied. An incompatible overwrite first removes VesEdge-managed `.npy` outputs and QC metadata from the previous batch so orphaned filtered results cannot remain under the new provenance.
 
 ### `qc_summary.csv`
 
-The summary contains one row per successfully loaded checkpoint with:
+The summary contains one row per selected checkpoint with:
 
 - total source frames;
 - successful edge detections;
@@ -276,8 +286,10 @@ The summary contains one row per successfully loaded checkpoint with:
 - population rejections;
 - accepted frames;
 - accepted fraction;
-- QC status;
-- any QC error message.
+- processing status;
+- any load or QC error message.
+
+A checkpoint that cannot be loaded receives a `load_error` row with zero counts and the loading error. Therefore `qc_summary.csv` is still written when every selected checkpoint fails to load.
 
 This file is intended to make it easy to compare how aggressive different QC configurations are before comparing the downstream EdgeMod results.
 
@@ -367,9 +379,9 @@ If downsampling is disabled, successful detections must have consistent analysis
 
 This is distinct from extraction failure. The checkpoint remains valid, but the selected QC configuration accepted no frames. The event is recorded in `qc_summary.csv` and no `.npy` is written for that checkpoint.
 
-### QC output directory already contains another configuration
+### QC output directory already contains another configuration or input selection
 
-Choose another `--output-dir`. Reusing one directory for multiple QC configurations makes provenance ambiguous and is intentionally blocked unless `--overwrite` is used.
+Choose another `--output-dir`. Reusing one directory for incompatible QC provenance is intentionally blocked unless `--overwrite` is used.
 
 ---
 

--- a/docs/custom_edge_extraction_algorithms.README.md
+++ b/docs/custom_edge_extraction_algorithms.README.md
@@ -94,15 +94,15 @@ def constant_radius_extractor(frame):
     return r_vals, vesicle_center
 ```
 
-Run it with:
+Run it during the extraction stage:
 
 ```bash
-vesedge sample.nd2 \
+vesedge extract sample.nd2 \
     --extractor-file ./constant_radius_extractor.py \
     --extractor-name constant_radius_extractor
 ```
 
-The current CLI extracts edges, applies its configured QC checks, and writes the accepted contours to `.npy` as usual.
+This writes a QC-independent `.npz` checkpoint. Apply QC later with `vesedge qc`.
 
 ---
 
@@ -111,7 +111,7 @@ The current CLI extracts edges, applies its configured QC checks, and writes the
 Use `--extractor` with `module:function` syntax:
 
 ```bash
-vesedge sample.nd2 \
+vesedge extract sample.nd2 \
     --extractor my_package.my_module:my_edge_extractor
 ```
 
@@ -144,7 +144,22 @@ After all frames are processed, extraction fails if:
 
 When every frame fails, the raised error includes the recorded extractor error messages so a custom-extractor failure can be diagnosed without relying on printed tracebacks.
 
-Quality-control outcomes are **not** extraction failures. `VesicleVideo.extract_edges()` itself does not run QC and returns a `VesicleEdges` object containing reusable extraction results. The current CLI then runs QC as a separate step internally.
+Quality-control outcomes are **not** extraction failures. `VesicleVideo.extract_edges()` and `vesedge extract` do not run QC. They produce reusable extraction results that can later be evaluated under different QC configurations.
+
+For example:
+
+```bash
+vesedge extract sample.nd2 \
+    --extractor-file ./my_extractor.py \
+    --extractor-name my_edge_extractor \
+    --output-dir ./checkpoints
+
+vesedge qc ./checkpoints \
+    --curvature-threshold 10 \
+    --output-dir ./results/qc_standard
+```
+
+This separation is useful when developing an extractor because changes to the extraction algorithm can be distinguished from changes to QC policy.
 
 ---
 

--- a/examples/VesEdge_example_usage.py
+++ b/examples/VesEdge_example_usage.py
@@ -1,4 +1,16 @@
-"""Example extraction, checkpoint, and re-QC workflow for VesEdge."""
+"""Example extraction, checkpoint, and re-QC workflow for VesEdge.
+
+Equivalent CLI workflow::
+
+    vesedge extract ./videos --pixels-per-micron 13.44 \
+        --downsample --n-samples 120 --output-dir ./checkpoints
+
+    vesedge qc ./checkpoints --curvature-threshold 10 \
+        --output-dir ./results/qc_standard
+
+    vesedge qc ./checkpoints --curvature-threshold 15 \
+        --output-dir ./results/qc_permissive
+"""
 
 import glob
 from pathlib import Path
@@ -34,15 +46,13 @@ for file in glob.glob(fpath + "*.nd2", recursive=True):
 
     # The checkpoint is the reusable output of extraction. It stores all
     # successful detections and extraction failures, but no QC decisions.
-    # Contours remain in image-space pixels; pixels_per_micron is stored with
-    # the checkpoint so physical radii can be derived later.
     edges.save_checkpoint(path)
 
-    # A GIF can be generated while the original image frames are available.
+    # A GIF can be generated only while the original image frames are present.
     video.make_vesicle_gif(path, edges)
 
 
-# Later, load a checkpoint and evaluate it under any QC configuration.
+# Later, load the same checkpoint and evaluate it under any QC configuration.
 qc_config = EdgeQCConfig(
     curvature_threshold=10,
     population_bic_threshold=10,
@@ -53,13 +63,13 @@ qc_config = EdgeQCConfig(
 # edges.run_qc(qc_config)
 # print(edges.qc_result.curvature)
 # print(edges.qc_result.population)
-# edges.save_edge_to_npy("YOUR/PATH/HERE/qc_standard/sample.npy")
+# edges.save_edge_to_npy("YOUR/PATH/HERE/results/qc_standard/sample.npy")
 
-# The same checkpoint can be evaluated again without rerunning extraction.
+# Evaluate the same checkpoint again without rerunning extraction.
 # permissive_qc = EdgeQCConfig(
 #     curvature_threshold=15,
 #     population_bic_threshold=10,
 #     max_minor_population_fraction=0.25,
 # )
 # edges.run_qc(permissive_qc)
-# edges.save_edge_to_npy("YOUR/PATH/HERE/qc_permissive/sample.npy")
+# edges.save_edge_to_npy("YOUR/PATH/HERE/results/qc_permissive/sample.npy")

--- a/tests/unit_tests/test_vesedge_cli.py
+++ b/tests/unit_tests/test_vesedge_cli.py
@@ -1,16 +1,20 @@
 """Unit tests for the VesEdge command-line interface."""
 
 import argparse
+import json
 from pathlib import Path
 
 import numpy as np
+import pytest
 
+from vesmod.VesEdge import EdgeQCConfig
 from vesmod.cli import vesedge_cli
 
 
-def _args() -> argparse.Namespace:
-    """Return standard CLI arguments for process_file tests."""
+def _extract_args(tmp_path=None) -> argparse.Namespace:
+    """Return standard extraction CLI arguments."""
     return argparse.Namespace(
+        output_dir=tmp_path,
         no_gif=True,
         overwrite=True,
         extractor_file=None,
@@ -19,18 +23,24 @@ def _args() -> argparse.Namespace:
         downsample=False,
         n_samples=120,
         pixels_per_micron=1.0,
+    )
+
+
+def _qc_args(tmp_path) -> argparse.Namespace:
+    """Return standard QC CLI arguments."""
+    return argparse.Namespace(
+        output_dir=tmp_path,
+        overwrite=True,
         curvature_threshold=5.0,
         population_bic_threshold=10.0,
         max_minor_population_fraction=0.25,
+        no_curvature_qc=False,
         no_population_qc=False,
     )
 
 
-def test_process_file_reports_extraction_failure_and_returns(
-    monkeypatch,
-    capsys,
-):
-    """Test that a per-file extraction failure does not abort batch processing."""
+def test_process_extract_file_reports_failure_and_returns(monkeypatch, capsys):
+    """Test that one extraction failure does not abort batch processing."""
 
     class FailingVideo:
         def __init__(self, frames):
@@ -40,7 +50,6 @@ def test_process_file_reports_extraction_failure_and_returns(
             raise ValueError("no successful detections")
 
     path = Path("failed.nd2")
-
     monkeypatch.setattr(
         vesedge_cli.nd2,
         "imread",
@@ -51,31 +60,27 @@ def test_process_file_reports_extraction_failure_and_returns(
         "load_extractor_from_module",
         lambda import_string: object(),
     )
-    monkeypatch.setattr(
-        vesedge_cli,
-        "VesicleVideo",
-        FailingVideo,
-    )
+    monkeypatch.setattr(vesedge_cli, "VesicleVideo", FailingVideo)
 
-    vesedge_cli.process_file(path, _args())
+    vesedge_cli.process_extract_file(path, _extract_args())
 
     captured = capsys.readouterr()
-    assert (
-        "Failed to process failed.nd2: no successful detections"
-        in captured.out
-    )
+    assert "Failed to extract failed.nd2: no successful detections" in captured.out
 
 
-def test_process_file_runs_qc_and_saves_filtered_output(monkeypatch):
-    """Test successful CLI processing applies QC and writes .npy output."""
+def test_process_extract_file_saves_checkpoint_without_running_qc(
+    tmp_path,
+    monkeypatch,
+):
+    """Test extraction writes a reusable checkpoint and does not run QC."""
     observed = {}
 
     class FakeEdges:
-        def run_qc(self, qc_config):
-            observed["qc_config"] = qc_config
+        def save_checkpoint(self, path):
+            observed["checkpoint"] = path
 
-        def save_edge_to_npy(self, path):
-            observed["npy"] = path
+        def run_qc(self, qc_config):
+            raise AssertionError("Extraction should not run QC")
 
     class SuccessfulVideo:
         def __init__(self, frames):
@@ -96,16 +101,144 @@ def test_process_file_runs_qc_and_saves_filtered_output(monkeypatch):
         "load_extractor_from_module",
         lambda import_string: object(),
     )
-    monkeypatch.setattr(
-        vesedge_cli,
-        "VesicleVideo",
-        SuccessfulVideo,
-    )
+    monkeypatch.setattr(vesedge_cli, "VesicleVideo", SuccessfulVideo)
 
-    vesedge_cli.process_file(path, _args())
+    vesedge_cli.process_extract_file(path, _extract_args(tmp_path))
 
-    assert observed["npy"] == path
+    assert observed["checkpoint"] == tmp_path / "sample.npz"
     assert observed["extraction_config"].pixels_per_micron == 1.0
     assert observed["extraction_config"].n_angular_samples is None
-    assert observed["qc_config"].curvature_threshold == 5.0
-    assert observed["qc_config"].enable_population_qc
+
+
+def test_process_qc_file_runs_qc_and_saves_filtered_output(tmp_path, monkeypatch):
+    """Test QC loads a checkpoint, applies QC, and writes accepted contours."""
+    observed = {}
+
+    class Detection:
+        def __init__(self):
+            self.qc = argparse.Namespace(flags=set(), passed=True)
+
+    class FakeEdges:
+        def __init__(self):
+            self.detections = [Detection(), Detection()]
+            self.successful_detections = self.detections
+            self.qc_result = None
+
+        def run_qc(self, config):
+            observed["qc_config"] = config
+            self.qc_result = object()
+
+        def save_edge_to_npy(self, path):
+            observed["npy"] = path
+
+    edges = FakeEdges()
+    monkeypatch.setattr(
+        vesedge_cli.VesicleEdges,
+        "from_checkpoint",
+        lambda path: edges,
+    )
+    args = _qc_args(tmp_path)
+    config = vesedge_cli._qc_config_from_args(args)
+
+    row = vesedge_cli.process_qc_file(Path("sample.npz"), args, config)
+
+    assert observed["npy"] == tmp_path / "sample.npy"
+    assert observed["qc_config"] is config
+    assert row["accepted"] == 2
+    assert row["status"] == "ok"
+
+
+def test_process_qc_file_records_zero_accepted_frames(tmp_path, monkeypatch):
+    """Test a completed QC run with no accepted frames is summarized."""
+
+    class Detection:
+        def __init__(self):
+            self.qc = argparse.Namespace(flags=set(), passed=False)
+
+    class FakeEdges:
+        def __init__(self):
+            self.detections = [Detection()]
+            self.successful_detections = self.detections
+            self.qc_result = None
+
+        def run_qc(self, config):
+            self.qc_result = object()
+            raise ValueError("no frames passed quality control")
+
+        def save_edge_to_npy(self, path):
+            raise AssertionError("No .npy should be saved")
+
+    edges = FakeEdges()
+    monkeypatch.setattr(
+        vesedge_cli.VesicleEdges,
+        "from_checkpoint",
+        lambda path: edges,
+    )
+    args = _qc_args(tmp_path)
+    config = vesedge_cli._qc_config_from_args(args)
+
+    row = vesedge_cli.process_qc_file(Path("sample.npz"), args, config)
+
+    assert row["accepted"] == 0
+    assert row["status"] == "no_accepted_frames"
+    assert "no frames passed quality control" in row["error"]
+
+
+def test_write_qc_provenance_rejects_different_configuration(tmp_path):
+    """Test a QC directory cannot silently mix configurations."""
+    config = EdgeQCConfig(5.0, 10.0, 0.25)
+    vesedge_cli._write_qc_provenance(
+        tmp_path,
+        config,
+        Path("checkpoints"),
+        overwrite=False,
+    )
+
+    different = EdgeQCConfig(8.0, 10.0, 0.25)
+    with pytest.raises(ValueError, match="different input path or QC configuration"):
+        vesedge_cli._write_qc_provenance(
+            tmp_path,
+            different,
+            Path("checkpoints"),
+            overwrite=False,
+        )
+
+
+def test_write_qc_provenance_records_configuration(tmp_path):
+    """Test QC provenance contains the exact configuration used."""
+    config = EdgeQCConfig(5.0, 10.0, 0.25)
+    vesedge_cli._write_qc_provenance(
+        tmp_path,
+        config,
+        Path("checkpoints"),
+        overwrite=False,
+    )
+
+    data = json.loads((tmp_path / "vesedge_qc.json").read_text())
+    assert data["qc_config"]["curvature_threshold"] == 5.0
+    assert data["qc_config"]["enable_population_qc"] is True
+
+
+def test_write_qc_summary_writes_batch_csv(tmp_path):
+    """Test QC summary output contains one row per processed checkpoint."""
+    rows = [
+        {
+            "file": "sample.npz",
+            "frames": 10,
+            "successful_detections": 9,
+            "extraction_failures": 1,
+            "curvature_rejected": 2,
+            "population_rejected": 1,
+            "accepted": 6,
+            "accepted_fraction": 2 / 3,
+            "status": "ok",
+            "error": "",
+        }
+    ]
+
+    vesedge_cli._write_qc_summary(tmp_path, rows)
+
+    summary = (tmp_path / "qc_summary.csv").read_text()
+    assert "sample.npz" in summary
+    assert "curvature_rejected" in summary
+    assert ",6," in summary

--- a/tests/unit_tests/test_vesedge_cli.py
+++ b/tests/unit_tests/test_vesedge_cli.py
@@ -12,9 +12,10 @@ from vesmod.VesEdge import EdgeQCConfig
 from vesmod.cli import vesedge_cli
 
 
-def _extract_args(tmp_path=None) -> argparse.Namespace:
+def _extract_args(tmp_path=None, input_path=Path("sample.nd2")) -> argparse.Namespace:
     """Return standard extraction CLI arguments."""
     return argparse.Namespace(
+        input_path=input_path,
         output_dir=tmp_path,
         no_gif=True,
         overwrite=True,
@@ -27,10 +28,12 @@ def _extract_args(tmp_path=None) -> argparse.Namespace:
     )
 
 
-def _qc_args(tmp_path) -> argparse.Namespace:
+def _qc_args(tmp_path, input_path=Path("sample.npz")) -> argparse.Namespace:
     """Return standard QC CLI arguments."""
     return argparse.Namespace(
+        input_path=input_path,
         output_dir=tmp_path,
+        recursive=False,
         overwrite=True,
         curvature_threshold=5.0,
         population_bic_threshold=10.0,
@@ -84,6 +87,34 @@ def test_parse_args_selects_qc_subcommand(monkeypatch, tmp_path):
     assert args.no_population_qc
 
 
+def test_iter_input_files_accepts_case_insensitive_suffixes(tmp_path):
+    """Test directory discovery treats suffix case like direct-file validation."""
+    lower = tmp_path / "lower.npz"
+    upper = tmp_path / "upper.NPZ"
+    ignored = tmp_path / "other.txt"
+    lower.touch()
+    upper.touch()
+    ignored.touch()
+
+    paths = vesedge_cli.iter_input_files(tmp_path, ".npz", recursive=False)
+
+    assert paths == sorted([lower, upper])
+
+
+def test_output_base_preserves_relative_subdirectories(tmp_path):
+    """Test equal stems in different input folders receive distinct outputs."""
+    input_root = tmp_path / "inputs"
+    first = input_root / "a" / "sample.nd2"
+    second = input_root / "b" / "sample.nd2"
+    output_dir = tmp_path / "outputs"
+
+    first_output = vesedge_cli._output_base(first, input_root, output_dir)
+    second_output = vesedge_cli._output_base(second, input_root, output_dir)
+
+    assert first_output == output_dir / "a" / "sample"
+    assert second_output == output_dir / "b" / "sample"
+
+
 def test_process_extract_file_reports_failure_and_returns(monkeypatch, capsys):
     """Test that one extraction failure does not abort batch processing."""
 
@@ -107,7 +138,7 @@ def test_process_extract_file_reports_failure_and_returns(monkeypatch, capsys):
     )
     monkeypatch.setattr(vesedge_cli, "VesicleVideo", FailingVideo)
 
-    vesedge_cli.process_extract_file(path, _extract_args())
+    vesedge_cli.process_extract_file(path, _extract_args(input_path=path))
 
     captured = capsys.readouterr()
     assert "Failed to extract failed.nd2: no successful detections" in captured.out
@@ -148,7 +179,7 @@ def test_process_extract_file_saves_checkpoint_without_running_qc(
     )
     monkeypatch.setattr(vesedge_cli, "VesicleVideo", SuccessfulVideo)
 
-    vesedge_cli.process_extract_file(path, _extract_args(tmp_path))
+    vesedge_cli.process_extract_file(path, _extract_args(tmp_path, path))
 
     assert observed["checkpoint"] == tmp_path / "sample.npz"
     assert observed["extraction_config"].pixels_per_micron == 1.0
@@ -176,21 +207,57 @@ def test_process_qc_file_runs_qc_and_saves_filtered_output(tmp_path, monkeypatch
         def save_edge_to_npy(self, path):
             observed["npy"] = path
 
+    path = Path("sample.npz")
     edges = FakeEdges()
     monkeypatch.setattr(
         vesedge_cli.VesicleEdges,
         "from_checkpoint",
-        lambda path: edges,
+        lambda checkpoint_path: edges,
     )
-    args = _qc_args(tmp_path)
+    args = _qc_args(tmp_path, path)
     config = vesedge_cli._qc_config_from_args(args)
 
-    row = vesedge_cli.process_qc_file(Path("sample.npz"), args, config)
+    row = vesedge_cli.process_qc_file(path, args, config)
 
     assert observed["npy"] == tmp_path / "sample.npy"
     assert observed["qc_config"] is config
     assert row["accepted"] == 2
     assert row["status"] == "ok"
+
+
+def test_process_qc_file_preserves_relative_output_path(tmp_path, monkeypatch):
+    """Test recursive QC outputs preserve checkpoint subdirectories."""
+    observed = {}
+
+    class Detection:
+        def __init__(self):
+            self.qc = argparse.Namespace(flags=set(), passed=True)
+
+    class FakeEdges:
+        detections = [Detection()]
+        successful_detections = detections
+        qc_result = object()
+
+        def run_qc(self, config):
+            pass
+
+        def save_edge_to_npy(self, path):
+            observed["npy"] = path
+
+    input_root = tmp_path / "checkpoints"
+    path = input_root / "nested" / "sample.npz"
+    output_dir = tmp_path / "qc"
+    monkeypatch.setattr(
+        vesedge_cli.VesicleEdges,
+        "from_checkpoint",
+        lambda checkpoint_path: FakeEdges(),
+    )
+    args = _qc_args(output_dir, input_root)
+    config = vesedge_cli._qc_config_from_args(args)
+
+    vesedge_cli.process_qc_file(path, args, config)
+
+    assert observed["npy"] == output_dir / "nested" / "sample.npy"
 
 
 def test_process_qc_file_records_zero_accepted_frames(tmp_path, monkeypatch):
@@ -213,58 +280,129 @@ def test_process_qc_file_records_zero_accepted_frames(tmp_path, monkeypatch):
         def save_edge_to_npy(self, path):
             raise AssertionError("No .npy should be saved")
 
+    path = Path("sample.npz")
     edges = FakeEdges()
     monkeypatch.setattr(
         vesedge_cli.VesicleEdges,
         "from_checkpoint",
-        lambda path: edges,
+        lambda checkpoint_path: edges,
     )
-    args = _qc_args(tmp_path)
+    args = _qc_args(tmp_path, path)
     config = vesedge_cli._qc_config_from_args(args)
 
-    row = vesedge_cli.process_qc_file(Path("sample.npz"), args, config)
+    row = vesedge_cli.process_qc_file(path, args, config)
 
     assert row["accepted"] == 0
     assert row["status"] == "no_accepted_frames"
     assert "no frames passed quality control" in row["error"]
 
 
+def test_process_qc_file_returns_load_error_summary(tmp_path, monkeypatch):
+    """Test checkpoint load failures still produce canonical summary rows."""
+    path = Path("broken.npz")
+    monkeypatch.setattr(
+        vesedge_cli.VesicleEdges,
+        "from_checkpoint",
+        lambda checkpoint_path: (_ for _ in ()).throw(ValueError("bad checkpoint")),
+    )
+    args = _qc_args(tmp_path, path)
+    config = vesedge_cli._qc_config_from_args(args)
+
+    row = vesedge_cli.process_qc_file(path, args, config)
+
+    assert row == {
+        "file": "broken.npz",
+        "frames": 0,
+        "successful_detections": 0,
+        "extraction_failures": 0,
+        "curvature_rejected": 0,
+        "population_rejected": 0,
+        "accepted": 0,
+        "accepted_fraction": 0.0,
+        "status": "load_error",
+        "error": "bad checkpoint",
+    }
+
+
 def test_write_qc_provenance_rejects_different_configuration(tmp_path):
     """Test a QC directory cannot silently mix configurations."""
+    checkpoint = tmp_path / "sample.npz"
     config = EdgeQCConfig(5.0, 10.0, 0.25)
     vesedge_cli._write_qc_provenance(
         tmp_path,
         config,
-        Path("checkpoints"),
+        checkpoint,
+        False,
+        [checkpoint],
         overwrite=False,
     )
 
     different = EdgeQCConfig(8.0, 10.0, 0.25)
-    with pytest.raises(
-        ValueError,
-        match="different input path or QC configuration",
-    ):
+    with pytest.raises(ValueError, match="different input selection or QC configuration"):
         vesedge_cli._write_qc_provenance(
             tmp_path,
             different,
-            Path("checkpoints"),
+            checkpoint,
+            False,
+            [checkpoint],
             overwrite=False,
         )
 
 
-def test_write_qc_provenance_records_configuration(tmp_path):
-    """Test QC provenance contains the exact configuration used."""
+def test_write_qc_provenance_records_manifest_and_recursive_setting(tmp_path):
+    """Test provenance identifies the exact resolved checkpoint selection."""
+    input_root = tmp_path / "checkpoints"
+    first = input_root / "a.npz"
+    second = input_root / "nested" / "b.npz"
     config = EdgeQCConfig(5.0, 10.0, 0.25)
+
     vesedge_cli._write_qc_provenance(
-        tmp_path,
+        tmp_path / "qc",
         config,
-        Path("checkpoints"),
+        input_root,
+        True,
+        [first, second],
         overwrite=False,
     )
 
-    data = json.loads((tmp_path / "vesedge_qc.json").read_text())
+    data = json.loads((tmp_path / "qc" / "vesedge_qc.json").read_text())
+    assert data["recursive"] is True
+    assert data["checkpoint_manifest"] == [str(first.resolve()), str(second.resolve())]
     assert data["qc_config"]["curvature_threshold"] == 5.0
-    assert data["qc_config"]["enable_population_qc"] is True
+
+
+def test_overwrite_incompatible_provenance_removes_stale_outputs(tmp_path):
+    """Test incompatible overwrite clears prior managed QC artifacts."""
+    output_dir = tmp_path / "qc"
+    checkpoint = tmp_path / "sample.npz"
+    config = EdgeQCConfig(5.0, 10.0, 0.25)
+    vesedge_cli._write_qc_provenance(
+        output_dir,
+        config,
+        checkpoint,
+        False,
+        [checkpoint],
+        overwrite=False,
+    )
+    stale = output_dir / "nested" / "orphan.npy"
+    stale.parent.mkdir(parents=True)
+    stale.touch()
+    (output_dir / "qc_summary.csv").write_text("old")
+
+    different = EdgeQCConfig(8.0, 10.0, 0.25)
+    vesedge_cli._write_qc_provenance(
+        output_dir,
+        different,
+        checkpoint,
+        False,
+        [checkpoint],
+        overwrite=True,
+    )
+
+    assert not stale.exists()
+    assert not (output_dir / "qc_summary.csv").exists()
+    data = json.loads((output_dir / "vesedge_qc.json").read_text())
+    assert data["qc_config"]["curvature_threshold"] == 8.0
 
 
 def test_write_qc_summary_writes_batch_csv(tmp_path):
@@ -290,3 +428,31 @@ def test_write_qc_summary_writes_batch_csv(tmp_path):
     assert "sample.npz" in summary
     assert "curvature_rejected" in summary
     assert ",6," in summary
+
+
+def test_run_qc_writes_summary_when_every_checkpoint_fails_to_load(
+    tmp_path,
+    monkeypatch,
+):
+    """Test an all-load-failure batch still writes qc_summary.csv."""
+    input_dir = tmp_path / "checkpoints"
+    input_dir.mkdir()
+    first = input_dir / "first.npz"
+    second = input_dir / "second.npz"
+    first.touch()
+    second.touch()
+    output_dir = tmp_path / "qc"
+    args = _qc_args(output_dir, input_dir)
+
+    monkeypatch.setattr(
+        vesedge_cli.VesicleEdges,
+        "from_checkpoint",
+        lambda checkpoint_path: (_ for _ in ()).throw(ValueError("bad checkpoint")),
+    )
+
+    vesedge_cli._run_qc(args)
+
+    summary = (output_dir / "qc_summary.csv").read_text()
+    assert "first.npz" in summary
+    assert "second.npz" in summary
+    assert summary.count("load_error") == 2

--- a/tests/unit_tests/test_vesedge_cli.py
+++ b/tests/unit_tests/test_vesedge_cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -37,6 +38,50 @@ def _qc_args(tmp_path) -> argparse.Namespace:
         no_curvature_qc=False,
         no_population_qc=False,
     )
+
+
+def test_parse_args_selects_extract_subcommand(monkeypatch):
+    """Test extraction arguments are scoped to the extract subcommand."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vesedge",
+            "extract",
+            "sample.nd2",
+            "--pixels-per-micron",
+            "13.44",
+        ],
+    )
+
+    args = vesedge_cli.parse_args()
+
+    assert args.command == "extract"
+    assert args.input_path == Path("sample.nd2")
+    assert args.pixels_per_micron == pytest.approx(13.44)
+
+
+def test_parse_args_selects_qc_subcommand(monkeypatch, tmp_path):
+    """Test QC arguments are scoped to the qc subcommand."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vesedge",
+            "qc",
+            "checkpoints",
+            "--output-dir",
+            str(tmp_path),
+            "--no-population-qc",
+        ],
+    )
+
+    args = vesedge_cli.parse_args()
+
+    assert args.command == "qc"
+    assert args.input_path == Path("checkpoints")
+    assert args.output_dir == tmp_path
+    assert args.no_population_qc
 
 
 def test_process_extract_file_reports_failure_and_returns(monkeypatch, capsys):
@@ -195,7 +240,10 @@ def test_write_qc_provenance_rejects_different_configuration(tmp_path):
     )
 
     different = EdgeQCConfig(8.0, 10.0, 0.25)
-    with pytest.raises(ValueError, match="different input path or QC configuration"):
+    with pytest.raises(
+        ValueError,
+        match="different input path or QC configuration",
+    ):
         vesedge_cli._write_qc_provenance(
             tmp_path,
             different,

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -1,10 +1,13 @@
-"""Command line tool for extracting vesicle edges from ND2 videos."""
+"""Command-line interface for VesEdge extraction and quality control."""
 
 from __future__ import annotations
 
 import argparse
+import csv
 import importlib
 import importlib.util
+import json
+from dataclasses import asdict
 from pathlib import Path
 
 import nd2
@@ -12,17 +15,31 @@ import nd2
 from vesmod.VesEdge import (
     EdgeExtractionConfig,
     EdgeQCConfig,
+    QCFlag,
+    VesicleEdges,
     VesicleVideo,
 )
 
 
 def parse_args() -> argparse.Namespace:
-    """Parse command line arguments."""
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         description=(
-            "Extract vesicle edges from one or more .nd2 files, apply quality "
-            "control, then save a GIF and .npy edge file for each video."
+            "Extract vesicle edges to reusable checkpoints, then apply quality "
+            "control in a separate stage."
         )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_extract_parser(subparsers)
+    _add_qc_parser(subparsers)
+    return parser.parse_args()
+
+
+def _add_extract_parser(subparsers) -> None:
+    """Add arguments for the extraction stage."""
+    parser = subparsers.add_parser(
+        "extract",
+        help="Extract edges from .nd2 files and save .npz checkpoints.",
     )
     parser.add_argument(
         "input_path",
@@ -35,15 +52,94 @@ def parse_args() -> argparse.Namespace:
         help="Search subdirectories when input_path is a directory.",
     )
     parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory for checkpoints and GIFs. By default, outputs are "
+            "written beside each input file."
+        ),
+    )
+    parser.add_argument(
         "--pixels-per-micron",
         type=float,
         default=1.0,
         help="Pixels per micron in the microscope image. Default: 1.",
     )
     parser.add_argument(
+        "--downsample",
+        action="store_true",
+        help=(
+            "Downsample edge-extraction outputs to --n-samples evenly spaced "
+            "angular values."
+        ),
+    )
+    parser.add_argument(
+        "--n-samples",
+        default=120,
+        type=int,
+        help="Angular samples used with --downsample. Default: 120.",
+    )
+    parser.add_argument(
+        "--extractor",
+        default="vesmod.VesEdge:extract_edge_from_frame",
+        help=(
+            "Edge extractor as 'module:function'. The function must accept one "
+            "2D frame and return (r_vals, vesicle_center)."
+        ),
+    )
+    parser.add_argument(
+        "--extractor-file",
+        default=None,
+        type=Path,
+        help="Path to a Python file containing a custom edge extractor.",
+    )
+    parser.add_argument(
+        "--extractor-name",
+        default="extract_edge_from_frame",
+        help="Name of the extractor function in --extractor-file.",
+    )
+    parser.add_argument(
+        "--no-gif",
+        action="store_true",
+        help="Do not save a GIF showing the extracted contours.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing extraction outputs.",
+    )
+
+
+def _add_qc_parser(subparsers) -> None:
+    """Add arguments for the QC stage."""
+    parser = subparsers.add_parser(
+        "qc",
+        help="Apply QC to .npz checkpoints and save filtered .npy files.",
+    )
+    parser.add_argument(
+        "input_path",
+        type=Path,
+        help="A VesEdge .npz checkpoint or directory containing checkpoints.",
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Search subdirectories when input_path is a directory.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help=(
+            "Directory for QC-filtered .npy files, vesedge_qc.json, and "
+            "qc_summary.csv. Use a separate directory for each QC configuration."
+        ),
+    )
+    parser.add_argument(
         "--curvature-threshold",
         type=float,
-        default=5,
+        default=5.0,
         help=(
             "Maximum wrapped finite second difference allowed by curvature QC. "
             "Default: 5."
@@ -63,9 +159,14 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=0.25,
         help=(
-            "Maximum fraction of detections that may belong to a minor "
-            "population for it to be rejected. Default: 0.25."
+            "Maximum fraction assigned to a minor population for automatic "
+            "rejection. Default: 0.25."
         ),
+    )
+    parser.add_argument(
+        "--no-curvature-qc",
+        action="store_true",
+        help="Disable frame-level curvature QC.",
     )
     parser.add_argument(
         "--no-population-qc",
@@ -73,67 +174,29 @@ def parse_args() -> argparse.Namespace:
         help="Disable trajectory-level center/radius population QC.",
     )
     parser.add_argument(
-        "--no-gif",
-        action="store_true",
-        help="Do not output a GIF.",
-    )
-    parser.add_argument(
-        "--downsample",
-        action="store_true",
-        help=(
-            "If used, downsample edge extraction outputs to --n-samples "
-            "evenly spaced values."
-        ),
-    )
-    parser.add_argument(
-        "--n-samples",
-        default=120,
-        type=int,
-        help=(
-            "If --downsample is used, downsample edge extraction outputs to "
-            "--n-samples evenly spaced values. Default: 120."
-        ),
-    )
-    parser.add_argument(
-        "--extractor",
-        default="vesmod.VesEdge:extract_edge_from_frame",
-        help=(
-            "Edge extractor function as 'module:function'. The function must "
-            "accept one 2D frame and return (r_vals, vesicle_center). Default: "
-            "vesmod.VesEdge:extract_edge_from_frame."
-        ),
-    )
-    parser.add_argument(
-        "--extractor-file",
-        default=None,
-        type=Path,
-        help="Path to a Python file containing a custom edge extractor function.",
-    )
-    parser.add_argument(
-        "--extractor-name",
-        default="extract_edge_from_frame",
-        help="Name of the extractor function in --extractor-file.",
-    )
-    parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="Process files even when corresponding output files already exist.",
+        help="Overwrite existing filtered .npy outputs.",
     )
-    return parser.parse_args()
 
 
-def iter_nd2_files(input_path: Path, recursive: bool) -> list[Path]:
-    """Return the .nd2 files selected by the user."""
+def iter_input_files(
+    input_path: Path,
+    suffix: str,
+    recursive: bool,
+) -> list[Path]:
+    """Return selected input files with the requested suffix."""
     input_path = input_path.expanduser().resolve()
+    suffix = suffix.lower()
     if input_path.is_file():
-        if input_path.suffix.lower() != ".nd2":
-            raise ValueError(f"Expected an .nd2 file, got: {input_path}")
+        if input_path.suffix.lower() != suffix:
+            raise ValueError(f"Expected a {suffix} file, got: {input_path}")
         return [input_path]
 
     if not input_path.is_dir():
         raise FileNotFoundError(f"Input path does not exist: {input_path}")
 
-    pattern = "**/*.nd2" if recursive else "*.nd2"
+    pattern = f"**/*{suffix}" if recursive else f"*{suffix}"
     return sorted(input_path.glob(pattern))
 
 
@@ -168,26 +231,27 @@ def load_extractor_from_file(file_path: Path, function_name: str):
     return extractor
 
 
-def process_file(path: Path, args: argparse.Namespace) -> None:
-    """Extract, QC, and save standard outputs for one ND2 video."""
-    output_paths = [path.with_suffix(".npy")]
-    if not args.no_gif:
-        output_paths.append(path.with_suffix(".gif"))
+def _output_base(path: Path, output_dir: Path | None) -> Path:
+    """Return output path without a suffix for one input file."""
+    if output_dir is None:
+        return path.with_suffix("")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir / path.stem
 
-    existing_paths = [
-        output_path
-        for output_path in output_paths
-        if output_path.exists()
-    ]
-    if existing_paths and not args.overwrite:
-        existing_names = ", ".join(
-            output_path.name
-            for output_path in existing_paths
-        )
-        print(
-            f"Skipping {path.name}: output file(s) already exist: "
-            f"{existing_names}"
-        )
+
+def process_extract_file(path: Path, args: argparse.Namespace) -> None:
+    """Extract one ND2 video and save a reusable checkpoint."""
+    output_base = _output_base(path, args.output_dir)
+    checkpoint_path = output_base.with_suffix(".npz")
+    gif_path = output_base.with_suffix(".gif")
+    output_paths = [checkpoint_path]
+    if not args.no_gif:
+        output_paths.append(gif_path)
+
+    existing = [output for output in output_paths if output.exists()]
+    if existing and not args.overwrite:
+        names = ", ".join(output.name for output in existing)
+        print(f"Skipping {path.name}: output file(s) already exist: {names}")
         return
 
     if args.extractor_file is not None:
@@ -198,49 +262,156 @@ def process_file(path: Path, args: argparse.Namespace) -> None:
     else:
         extractor_func = load_extractor_from_module(args.extractor)
 
-    print(f"Working on file {path.stem}")
+    print(f"Extracting {path.name}")
     intensities = nd2.imread(path)
     extraction_config = EdgeExtractionConfig(
         pixels_per_micron=args.pixels_per_micron,
-        n_angular_samples=(
-            args.n_samples if args.downsample else None
-        ),
-    )
-    qc_config = EdgeQCConfig(
-        curvature_threshold=args.curvature_threshold,
-        population_bic_threshold=args.population_bic_threshold,
-        max_minor_population_fraction=args.max_minor_population_fraction,
-        enable_curvature_qc=True,
-        enable_population_qc=not args.no_population_qc,
+        n_angular_samples=(args.n_samples if args.downsample else None),
     )
     video = VesicleVideo(intensities)
 
     try:
-        edges = video.extract_edges(
-            extractor_func,
-            extraction_config,
-        )
-        edges.run_qc(qc_config)
-    except ValueError as error:
-        print(
-            f"Failed to process {path.name}: {error}"
-        )
+        edges = video.extract_edges(extractor_func, extraction_config)
+        edges.save_checkpoint(checkpoint_path)
+    except (IndexError, ValueError) as error:
+        print(f"Failed to extract {path.name}: {error}")
         return
 
     if not args.no_gif:
-        video.make_vesicle_gif(path, edges)
-    edges.save_edge_to_npy(path)
+        video.make_vesicle_gif(gif_path, edges)
+
+
+def _qc_config_from_args(args: argparse.Namespace) -> EdgeQCConfig:
+    """Build the QC configuration requested on the command line."""
+    return EdgeQCConfig(
+        curvature_threshold=args.curvature_threshold,
+        population_bic_threshold=args.population_bic_threshold,
+        max_minor_population_fraction=args.max_minor_population_fraction,
+        enable_curvature_qc=not args.no_curvature_qc,
+        enable_population_qc=not args.no_population_qc,
+    )
+
+
+def _write_qc_provenance(
+    output_dir: Path,
+    qc_config: EdgeQCConfig,
+    input_path: Path,
+) -> None:
+    """Write the QC configuration used for one batch."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    provenance = {
+        "input_path": str(input_path.expanduser().resolve()),
+        "qc_config": asdict(qc_config),
+    }
+    provenance_path = output_dir / "vesedge_qc.json"
+    provenance_path.write_text(
+        json.dumps(provenance, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _qc_summary(path: Path, edges: VesicleEdges, status: str, error: str = "") -> dict:
+    """Build a summary row for one QCed checkpoint."""
+    successful = edges.successful_detections
+    curvature_rejected = sum(
+        QCFlag.CURVATURE in detection.qc.flags
+        for detection in successful
+    )
+    population_rejected = sum(
+        QCFlag.POPULATION_OUTLIER in detection.qc.flags
+        for detection in successful
+    )
+    accepted = sum(detection.qc.passed for detection in successful)
+    return {
+        "file": path.name,
+        "frames": len(edges.detections),
+        "successful_detections": len(successful),
+        "extraction_failures": len(edges.detections) - len(successful),
+        "curvature_rejected": curvature_rejected,
+        "population_rejected": population_rejected,
+        "accepted": accepted,
+        "accepted_fraction": accepted / len(successful),
+        "status": status,
+        "error": error,
+    }
+
+
+def process_qc_file(
+    path: Path,
+    args: argparse.Namespace,
+    qc_config: EdgeQCConfig,
+) -> dict | None:
+    """Apply QC to one checkpoint and save its accepted contours."""
+    output_path = args.output_dir / path.with_suffix(".npy").name
+    if output_path.exists() and not args.overwrite:
+        print(f"Skipping output for {path.name}: {output_path.name} already exists")
+
+    try:
+        edges = VesicleEdges.from_checkpoint(path)
+    except (FileNotFoundError, ValueError) as error:
+        print(f"Failed to load {path.name}: {error}")
+        return None
+
+    qc_error = ""
+    status = "ok"
+    try:
+        edges.run_qc(qc_config)
+    except ValueError as error:
+        qc_error = str(error)
+        status = "no_accepted_frames"
+        print(f"QC produced no accepted frames for {path.name}: {error}")
+
+    row = _qc_summary(path, edges, status, qc_error)
+    if row["accepted"] > 0 and (args.overwrite or not output_path.exists()):
+        edges.save_edge_to_npy(output_path)
+    return row
+
+
+def _write_qc_summary(output_dir: Path, rows: list[dict]) -> None:
+    """Write one CSV row per checkpoint in the QC batch."""
+    if not rows:
+        return
+    summary_path = output_dir / "qc_summary.csv"
+    with summary_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _run_extract(args: argparse.Namespace) -> None:
+    """Run the extraction subcommand."""
+    paths = iter_input_files(args.input_path, ".nd2", args.recursive)
+    if not paths:
+        raise FileNotFoundError(f"No .nd2 files found in {args.input_path}")
+    for path in paths:
+        process_extract_file(path, args)
+
+
+def _run_qc(args: argparse.Namespace) -> None:
+    """Run the QC subcommand."""
+    paths = iter_input_files(args.input_path, ".npz", args.recursive)
+    if not paths:
+        raise FileNotFoundError(f"No .npz files found in {args.input_path}")
+
+    qc_config = _qc_config_from_args(args)
+    args.output_dir = args.output_dir.expanduser().resolve()
+    _write_qc_provenance(args.output_dir, qc_config, args.input_path)
+
+    rows = []
+    for path in paths:
+        row = process_qc_file(path, args, qc_config)
+        if row is not None:
+            rows.append(row)
+    _write_qc_summary(args.output_dir, rows)
 
 
 def main() -> None:
-    """Run the command line interface."""
+    """Run the VesEdge command-line interface."""
     args = parse_args()
-    paths = iter_nd2_files(args.input_path, args.recursive)
-    if not paths:
-        raise FileNotFoundError(f"No .nd2 files found in {args.input_path}")
-
-    for path in paths:
-        process_file(path, args)
+    if args.command == "extract":
+        _run_extract(args)
+    else:
+        _run_qc(args)
 
 
 if __name__ == "__main__":

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -176,7 +176,7 @@ def _add_qc_parser(subparsers) -> None:
     parser.add_argument(
         "--overwrite",
         action="store_true",
-        help="Overwrite existing filtered .npy outputs.",
+        help="Overwrite existing filtered .npy outputs and QC provenance.",
     )
 
 
@@ -292,25 +292,50 @@ def _qc_config_from_args(args: argparse.Namespace) -> EdgeQCConfig:
     )
 
 
+def _qc_provenance(
+    qc_config: EdgeQCConfig,
+    input_path: Path,
+) -> dict:
+    """Return serializable provenance for one QC batch."""
+    return {
+        "input_path": str(input_path.expanduser().resolve()),
+        "qc_config": asdict(qc_config),
+    }
+
+
 def _write_qc_provenance(
     output_dir: Path,
     qc_config: EdgeQCConfig,
     input_path: Path,
+    overwrite: bool,
 ) -> None:
-    """Write the QC configuration used for one batch."""
+    """Write QC provenance and reject incompatible existing provenance."""
     output_dir.mkdir(parents=True, exist_ok=True)
-    provenance = {
-        "input_path": str(input_path.expanduser().resolve()),
-        "qc_config": asdict(qc_config),
-    }
     provenance_path = output_dir / "vesedge_qc.json"
+    provenance = _qc_provenance(qc_config, input_path)
+
+    if provenance_path.exists() and not overwrite:
+        existing = json.loads(provenance_path.read_text(encoding="utf-8"))
+        if existing != provenance:
+            raise ValueError(
+                "QC output directory already contains results from a different "
+                "input path or QC configuration. Choose another --output-dir "
+                "or use --overwrite."
+            )
+        return
+
     provenance_path.write_text(
         json.dumps(provenance, indent=2) + "\n",
         encoding="utf-8",
     )
 
 
-def _qc_summary(path: Path, edges: VesicleEdges, status: str, error: str = "") -> dict:
+def _qc_summary(
+    path: Path,
+    edges: VesicleEdges,
+    status: str,
+    error: str = "",
+) -> dict:
     """Build a summary row for one QCed checkpoint."""
     successful = edges.successful_detections
     curvature_rejected = sum(
@@ -343,8 +368,9 @@ def process_qc_file(
 ) -> dict | None:
     """Apply QC to one checkpoint and save its accepted contours."""
     output_path = args.output_dir / path.with_suffix(".npy").name
-    if output_path.exists() and not args.overwrite:
-        print(f"Skipping output for {path.name}: {output_path.name} already exists")
+    output_exists = output_path.exists()
+    if output_exists and not args.overwrite:
+        print(f"Keeping existing output for {path.name}: {output_path.name}")
 
     try:
         edges = VesicleEdges.from_checkpoint(path)
@@ -352,23 +378,31 @@ def process_qc_file(
         print(f"Failed to load {path.name}: {error}")
         return None
 
-    qc_error = ""
     status = "ok"
+    qc_error = ""
     try:
         edges.run_qc(qc_config)
     except ValueError as error:
         qc_error = str(error)
-        status = "no_accepted_frames"
-        print(f"QC produced no accepted frames for {path.name}: {error}")
+        if edges.qc_result is None:
+            status = "qc_error"
+            print(f"QC failed for {path.name}: {error}")
+        else:
+            status = "no_accepted_frames"
+            print(f"QC produced no accepted frames for {path.name}: {error}")
 
     row = _qc_summary(path, edges, status, qc_error)
-    if row["accepted"] > 0 and (args.overwrite or not output_path.exists()):
+    if (
+        status == "ok"
+        and row["accepted"] > 0
+        and (args.overwrite or not output_exists)
+    ):
         edges.save_edge_to_npy(output_path)
     return row
 
 
 def _write_qc_summary(output_dir: Path, rows: list[dict]) -> None:
-    """Write one CSV row per checkpoint in the QC batch."""
+    """Write one CSV row per successfully loaded checkpoint in the QC batch."""
     if not rows:
         return
     summary_path = output_dir / "qc_summary.csv"
@@ -395,7 +429,12 @@ def _run_qc(args: argparse.Namespace) -> None:
 
     qc_config = _qc_config_from_args(args)
     args.output_dir = args.output_dir.expanduser().resolve()
-    _write_qc_provenance(args.output_dir, qc_config, args.input_path)
+    _write_qc_provenance(
+        args.output_dir,
+        qc_config,
+        args.input_path,
+        args.overwrite,
+    )
 
     rows = []
     for path in paths:

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -196,8 +196,12 @@ def iter_input_files(
     if not input_path.is_dir():
         raise FileNotFoundError(f"Input path does not exist: {input_path}")
 
-    pattern = f"**/*{suffix}" if recursive else f"*{suffix}"
-    return sorted(input_path.glob(pattern))
+    pattern = "**/*" if recursive else "*"
+    return sorted(
+        candidate
+        for candidate in input_path.glob(pattern)
+        if candidate.is_file() and candidate.suffix.lower() == suffix
+    )
 
 
 def load_extractor_from_module(import_string: str):
@@ -231,27 +235,36 @@ def load_extractor_from_file(file_path: Path, function_name: str):
     return extractor
 
 
-def _output_base(path: Path, output_dir: Path | None) -> Path:
-    """Return output path without a suffix for one input file."""
+def _relative_input_path(path: Path, input_path: Path) -> Path:
+    """Return one selected file relative to the user-selected input root."""
+    resolved_path = path.expanduser().resolve()
+    resolved_input = input_path.expanduser().resolve()
+    if resolved_path == resolved_input:
+        return Path(resolved_path.name)
+    return resolved_path.relative_to(resolved_input)
+
+
+def _output_base(
+    path: Path,
+    input_path: Path,
+    output_dir: Path | None,
+) -> Path:
+    """Return an output path stem while preserving relative input directories."""
     if output_dir is None:
         return path.with_suffix("")
-    output_dir.mkdir(parents=True, exist_ok=True)
-    return output_dir / path.stem
+    output_base = output_dir / _relative_input_path(path, input_path).with_suffix("")
+    output_base.parent.mkdir(parents=True, exist_ok=True)
+    return output_base
 
 
 def process_extract_file(path: Path, args: argparse.Namespace) -> None:
     """Extract one ND2 video and save a reusable checkpoint."""
-    output_base = _output_base(path, args.output_dir)
+    output_base = _output_base(path, args.input_path, args.output_dir)
     checkpoint_path = output_base.with_suffix(".npz")
     gif_path = output_base.with_suffix(".gif")
-    output_paths = [checkpoint_path]
-    if not args.no_gif:
-        output_paths.append(gif_path)
 
-    existing = [output for output in output_paths if output.exists()]
-    if existing and not args.overwrite:
-        names = ", ".join(output.name for output in existing)
-        print(f"Skipping {path.name}: output file(s) already exist: {names}")
+    if checkpoint_path.exists() and not args.overwrite:
+        print(f"Skipping {path.name}: checkpoint already exists: {checkpoint_path.name}")
         return
 
     if args.extractor_file is not None:
@@ -277,7 +290,7 @@ def process_extract_file(path: Path, args: argparse.Namespace) -> None:
         print(f"Failed to extract {path.name}: {error}")
         return
 
-    if not args.no_gif:
+    if not args.no_gif and (args.overwrite or not gif_path.exists()):
         video.make_vesicle_gif(gif_path, edges)
 
 
@@ -295,34 +308,52 @@ def _qc_config_from_args(args: argparse.Namespace) -> EdgeQCConfig:
 def _qc_provenance(
     qc_config: EdgeQCConfig,
     input_path: Path,
+    recursive: bool,
+    paths: list[Path],
 ) -> dict:
-    """Return serializable provenance for one QC batch."""
+    """Return serializable provenance for one resolved QC batch."""
     return {
         "input_path": str(input_path.expanduser().resolve()),
+        "recursive": recursive,
+        "checkpoint_manifest": [str(path.resolve()) for path in paths],
         "qc_config": asdict(qc_config),
     }
+
+
+def _remove_managed_qc_artifacts(output_dir: Path) -> None:
+    """Remove filtered arrays and metadata managed by a previous QC batch."""
+    for output_path in output_dir.rglob("*.npy"):
+        output_path.unlink()
+    for filename in ("qc_summary.csv", "vesedge_qc.json"):
+        output_path = output_dir / filename
+        if output_path.exists():
+            output_path.unlink()
 
 
 def _write_qc_provenance(
     output_dir: Path,
     qc_config: EdgeQCConfig,
     input_path: Path,
+    recursive: bool,
+    paths: list[Path],
     overwrite: bool,
 ) -> None:
     """Write QC provenance and reject incompatible existing provenance."""
     output_dir.mkdir(parents=True, exist_ok=True)
     provenance_path = output_dir / "vesedge_qc.json"
-    provenance = _qc_provenance(qc_config, input_path)
+    provenance = _qc_provenance(qc_config, input_path, recursive, paths)
 
-    if provenance_path.exists() and not overwrite:
+    if provenance_path.exists():
         existing = json.loads(provenance_path.read_text(encoding="utf-8"))
-        if existing != provenance:
+        if existing == provenance:
+            return
+        if not overwrite:
             raise ValueError(
                 "QC output directory already contains results from a different "
-                "input path or QC configuration. Choose another --output-dir "
+                "input selection or QC configuration. Choose another --output-dir "
                 "or use --overwrite."
             )
-        return
+        _remove_managed_qc_artifacts(output_dir)
 
     provenance_path.write_text(
         json.dumps(provenance, indent=2) + "\n",
@@ -332,6 +363,7 @@ def _write_qc_provenance(
 
 def _qc_summary(
     path: Path,
+    input_path: Path,
     edges: VesicleEdges,
     status: str,
     error: str = "",
@@ -348,7 +380,7 @@ def _qc_summary(
     )
     accepted = sum(detection.qc.passed for detection in successful)
     return {
-        "file": path.name,
+        "file": str(_relative_input_path(path, input_path)),
         "frames": len(edges.detections),
         "successful_detections": len(successful),
         "extraction_failures": len(edges.detections) - len(successful),
@@ -361,13 +393,33 @@ def _qc_summary(
     }
 
 
+def _load_error_summary(path: Path, input_path: Path, error: str) -> dict:
+    """Build a canonical summary row for a checkpoint that could not load."""
+    return {
+        "file": str(_relative_input_path(path, input_path)),
+        "frames": 0,
+        "successful_detections": 0,
+        "extraction_failures": 0,
+        "curvature_rejected": 0,
+        "population_rejected": 0,
+        "accepted": 0,
+        "accepted_fraction": 0.0,
+        "status": "load_error",
+        "error": error,
+    }
+
+
 def process_qc_file(
     path: Path,
     args: argparse.Namespace,
     qc_config: EdgeQCConfig,
-) -> dict | None:
-    """Apply QC to one checkpoint and save its accepted contours."""
-    output_path = args.output_dir / path.with_suffix(".npy").name
+) -> dict:
+    """Apply QC to one checkpoint and return its batch summary row."""
+    output_path = (
+        args.output_dir
+        / _relative_input_path(path, args.input_path).with_suffix(".npy")
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     output_exists = output_path.exists()
     if output_exists and not args.overwrite:
         print(f"Keeping existing output for {path.name}: {output_path.name}")
@@ -375,8 +427,9 @@ def process_qc_file(
     try:
         edges = VesicleEdges.from_checkpoint(path)
     except (FileNotFoundError, ValueError) as error:
-        print(f"Failed to load {path.name}: {error}")
-        return None
+        message = str(error)
+        print(f"Failed to load {path.name}: {message}")
+        return _load_error_summary(path, args.input_path, message)
 
     status = "ok"
     qc_error = ""
@@ -391,7 +444,7 @@ def process_qc_file(
             status = "no_accepted_frames"
             print(f"QC produced no accepted frames for {path.name}: {error}")
 
-    row = _qc_summary(path, edges, status, qc_error)
+    row = _qc_summary(path, args.input_path, edges, status, qc_error)
     if (
         status == "ok"
         and row["accepted"] > 0
@@ -402,7 +455,7 @@ def process_qc_file(
 
 
 def _write_qc_summary(output_dir: Path, rows: list[dict]) -> None:
-    """Write one CSV row per successfully loaded checkpoint in the QC batch."""
+    """Write one CSV row per selected checkpoint in the QC batch."""
     if not rows:
         return
     summary_path = output_dir / "qc_summary.csv"
@@ -433,14 +486,12 @@ def _run_qc(args: argparse.Namespace) -> None:
         args.output_dir,
         qc_config,
         args.input_path,
+        args.recursive,
+        paths,
         args.overwrite,
     )
 
-    rows = []
-    for path in paths:
-        row = process_qc_file(path, args, qc_config)
-        if row is not None:
-            rows.append(row)
+    rows = [process_qc_file(path, args, qc_config) for path in paths]
     _write_qc_summary(args.output_dir, rows)
 
 


### PR DESCRIPTION
## Description

Update the VesEdge command-line interface to match the separation between edge extraction and quality control introduced by the VesEdge refactor.

Previously, one `vesedge` invocation extracted edges, immediately applied QC, and wrote only the accepted contours to `.npy`. This meant that changing a QC threshold required repeating the image-dependent edge extraction step.

This PR separates the CLI into two explicit stages:

1. `vesedge extract` performs edge extraction and writes a reusable, QC-independent `.npz` checkpoint.
2. `vesedge qc` loads one or more checkpoints, applies a specified QC configuration, and writes the accepted contours to `.npy` for EdgeMod.

This makes QC configurations directly comparable without rerunning edge extraction. The QC stage also records the configuration and a per-video summary so the relationship between a filtered dataset and the QC settings that produced it is explicit.

## Usage Changes

The previous single-stage usage:

```bash
vesedge sample.nd2 --pixels-per-micron 13.44 --downsample --n-samples 120
```

is replaced by an extraction stage followed by a QC stage.

### Extract edges

```bash
vesedge extract ./videos \
    --pixels-per-micron 13.44 \
    --downsample \
    --n-samples 120 \
    --output-dir ./checkpoints
```

Extraction writes `.npz` checkpoints containing the extraction results and configuration but no QC decisions. GIF generation remains available during this stage because the original image frames are available.

### Apply QC

```bash
vesedge qc ./checkpoints \
    --curvature-threshold 5 \
    --population-bic-threshold 10 \
    --max-minor-population-fraction 0.25 \
    --output-dir ./results/qc_standard
```

The QC output directory contains the accepted `.npy` contour files plus:

- `vesedge_qc.json`: the input path and exact QC configuration used for the batch.
- `qc_summary.csv`: per-checkpoint counts of total frames, successful detections, extraction failures, curvature rejections, population rejections, accepted frames, and accepted fraction, plus processing status/errors.

`--no-curvature-qc` and `--no-population-qc` can disable the corresponding QC stages.

A QC output directory cannot silently be reused with a different input path or QC configuration. A separate output directory should normally be used for each QC configuration; `--overwrite` permits intentional replacement.

The intended workflow is therefore:

```text
ND2 videos
    ↓
vesedge extract
    ↓
QC-independent .npz checkpoints
    ├── vesedge qc → qc_configuration_A/*.npy → edgemod
    ├── vesedge qc → qc_configuration_B/*.npy → edgemod
    └── vesedge qc → qc_configuration_C/*.npy → edgemod
```

This allows the effects of QC choices on both frame retention and downstream bending-modulus estimates to be evaluated without changing the underlying edge extractions.

## Todos

Notable points that this PR has either accomplished or will accomplish.

- [x] Separate CLI edge extraction from QC.
- [x] Save reusable `.npz` checkpoints from `vesedge extract`.
- [x] Allow `vesedge qc` to apply different QC configurations to existing checkpoints.
- [x] Write QC-filtered `.npy` files for EdgeMod.
- [x] Record QC configuration provenance in `vesedge_qc.json`.
- [x] Write a per-video `qc_summary.csv` for comparing QC configurations.
- [x] Distinguish extraction failure, QC failure, and QC runs that accept zero frames.
- [x] Add tests for the staged CLI and subcommand parsing.
- [x] Update VesEdge, EdgeMod, custom-extractor, example, and top-level documentation for the new workflow.

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] New configuration parameters are documented (Usage changes above)
- [ ] Changes propagated to all notebooks

## Review checklist (Reviewer)
- [ ] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] All notebooks still function correctly

## Status
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split the VesEdge workflow into separate extraction and QC stages.
  * Save reusable checkpoints for repeated QC runs with different settings.
  * Export filtered results, provenance metadata, and batch QC summaries.
  * Support configurable output directories, overwrite handling, and optional GIFs.
  * Enable EdgeMod workflows using VesEdge QC output.
* **Documentation**
  * Updated CLI, Python workflow, custom algorithm, output-format, troubleshooting, and EdgeMod guidance.
* **Tests**
  * Added coverage for extraction, QC, checkpoint reuse, provenance validation, and summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->