### PR TITLE
69 preserve source frame identity

### DIFF
--- a/tests/unit_tests/test_checkpoint_io_validation.py
+++ b/tests/unit_tests/test_checkpoint_io_validation.py
@@ -1,0 +1,83 @@
+"""Unit tests for VesEdge checkpoint frame-index validation."""
+
+import numpy as np
+import pytest
+
+from vesmod.VesEdge.checkpoint_io import save_checkpoint
+from vesmod.VesEdge.config import EdgeExtractionConfig
+from vesmod.VesEdge.models import EdgeDetection, ImageContour
+
+
+def _detection(frame_index):
+    """Return a minimal detection with an explicit frame index."""
+    contour = ImageContour((0.0, 0.0), np.ones(4, dtype=float))
+    return EdgeDetection(
+        contour,
+        contour,
+        frame_index=frame_index,
+    )
+
+
+@pytest.fixture
+def extraction_config():
+    """Return checkpoint-compatible extraction settings."""
+    return EdgeExtractionConfig(
+        pixels_per_micron=1.0,
+        n_angular_samples=4,
+    )
+
+
+@pytest.mark.parametrize("frame_index", [None, "0", 0.0, True, np.bool_(False)])
+def test_save_checkpoint_rejects_non_integer_frame_indices(
+    tmp_path,
+    extraction_config,
+    frame_index,
+):
+    """Test invalid frame-index types raise the intended ValueError."""
+    detection = _detection(frame_index)
+
+    with pytest.raises(
+        ValueError,
+        match="missing or inconsistent frame indices",
+    ):
+        save_checkpoint(
+            tmp_path / "invalid.npz",
+            extraction_config,
+            [detection],
+        )
+
+
+def test_save_checkpoint_accepts_numpy_integer_frame_index(
+    tmp_path,
+    extraction_config,
+):
+    """Test NumPy integer indices are accepted before int64 coercion."""
+    detection = _detection(np.int32(0))
+
+    save_checkpoint(
+        tmp_path / "valid.npz",
+        extraction_config,
+        [detection],
+    )
+
+    with np.load(tmp_path / "valid.npz", allow_pickle=False) as checkpoint:
+        assert checkpoint["frame_indices"].dtype == np.int64
+        np.testing.assert_array_equal(checkpoint["frame_indices"], [0])
+
+
+def test_save_checkpoint_still_rejects_nonsequential_integer_indices(
+    tmp_path,
+    extraction_config,
+):
+    """Test valid integer types must still match source-frame ordering."""
+    detection = _detection(1)
+
+    with pytest.raises(
+        ValueError,
+        match="missing or inconsistent frame indices",
+    ):
+        save_checkpoint(
+            tmp_path / "invalid.npz",
+            extraction_config,
+            [detection],
+        )

--- a/tests/unit_tests/test_vesicle_edges.py
+++ b/tests/unit_tests/test_vesicle_edges.py
@@ -230,9 +230,10 @@ def test_checkpoint_round_trip_preserves_extraction_not_qc(
     extraction_config,
     qc_config,
 ):
-    """Test checkpointing preserves extraction state and frame identity."""
+    """Test checkpointing preserves extraction state and source provenance."""
     first = _edge(radius=10.0)
     second = _edge(radius=12.0)
+    source_path = tmp_path / "source.nd2"
     edge_results = VesicleEdges(
         extraction_config=extraction_config,
         detections=[
@@ -240,6 +241,7 @@ def test_checkpoint_round_trip_preserves_extraction_not_qc(
             EdgeDetectionFailure("bad frame"),
             second,
         ],
+        source_path=source_path,
     )
     edge_results.run_qc(qc_config)
     edge_results.save_checkpoint(tmp_path / "sample")
@@ -249,6 +251,7 @@ def test_checkpoint_round_trip_preserves_extraction_not_qc(
     assert loaded.qc_result is None
     assert loaded.qc_config is None
     assert loaded.extraction_config == extraction_config
+    assert loaded.source_path == source_path
     assert isinstance(loaded.detections[0], EdgeDetection)
     assert isinstance(loaded.detections[1], EdgeDetectionFailure)
     assert loaded.detections[1].error == "bad frame"
@@ -264,11 +267,11 @@ def test_checkpoint_round_trip_preserves_extraction_not_qc(
     )
 
 
-def test_checkpoint_without_frame_indices_infers_from_order(
+def test_checkpoint_without_optional_provenance_infers_available_data(
     tmp_path,
     extraction_config,
 ):
-    """Test checkpoints without frame indices recover them from stored order."""
+    """Test older checkpoints infer frame indices and omit unknown source path."""
     edge_results = VesicleEdges(
         extraction_config=extraction_config,
         detections=[
@@ -276,6 +279,7 @@ def test_checkpoint_without_frame_indices_infers_from_order(
             EdgeDetectionFailure("bad frame"),
             _edge(radius=12.0),
         ],
+        source_path=tmp_path / "source.nd2",
     )
     current_path = tmp_path / "current.npz"
     edge_results.save_checkpoint(current_path)
@@ -284,14 +288,15 @@ def test_checkpoint_without_frame_indices_infers_from_order(
         legacy_data = {
             key: checkpoint[key].copy()
             for key in checkpoint.files
-            if key != "frame_indices"
+            if key not in {"frame_indices", "source_path"}
         }
-    legacy_path = tmp_path / "without_frame_indices.npz"
+    legacy_path = tmp_path / "legacy.npz"
     np.savez(legacy_path, **legacy_data)
 
     loaded = VesicleEdges.from_checkpoint(legacy_path)
 
     assert [result.frame_index for result in loaded.detections] == [0, 1, 2]
+    assert loaded.source_path is None
     assert isinstance(loaded.detections[1], EdgeDetectionFailure)
     assert loaded.detections[1].error == "bad frame"
 

--- a/tests/unit_tests/test_vesicle_edges.py
+++ b/tests/unit_tests/test_vesicle_edges.py
@@ -264,11 +264,11 @@ def test_checkpoint_round_trip_preserves_extraction_not_qc(
     )
 
 
-def test_checkpoint_v1_load_infers_frame_indices(
+def test_checkpoint_without_frame_indices_infers_from_order(
     tmp_path,
     extraction_config,
 ):
-    """Test legacy v1 checkpoints recover frame identity from stored order."""
+    """Test checkpoints without frame indices recover them from stored order."""
     edge_results = VesicleEdges(
         extraction_config=extraction_config,
         detections=[
@@ -286,8 +286,7 @@ def test_checkpoint_v1_load_infers_frame_indices(
             for key in checkpoint.files
             if key != "frame_indices"
         }
-    legacy_data["checkpoint_version"] = np.asarray(1)
-    legacy_path = tmp_path / "legacy_v1.npz"
+    legacy_path = tmp_path / "without_frame_indices.npz"
     np.savez(legacy_path, **legacy_data)
 
     loaded = VesicleEdges.from_checkpoint(legacy_path)

--- a/tests/unit_tests/test_vesicle_edges.py
+++ b/tests/unit_tests/test_vesicle_edges.py
@@ -72,6 +72,32 @@ def test_successful_detections_excludes_failures(extraction_config):
     assert edge_results.successful_detections == [first, second]
 
 
+def test_post_init_backfills_legacy_frame_indices(extraction_config):
+    """Test legacy/manual results gain source indices from stored order."""
+    edge_results = VesicleEdges(
+        extraction_config=extraction_config,
+        detections=[
+            _edge(),
+            EdgeDetectionFailure("failure"),
+            _edge(radius=12.0),
+        ],
+    )
+
+    assert [result.frame_index for result in edge_results.detections] == [0, 1, 2]
+
+
+def test_post_init_rejects_inconsistent_frame_index(extraction_config):
+    """Test explicit source indices must agree with trajectory position."""
+    detection = _edge()
+    detection.frame_index = 3
+
+    with pytest.raises(ValueError, match="frame_index"):
+        VesicleEdges(
+            extraction_config=extraction_config,
+            detections=[detection],
+        )
+
+
 def test_accepted_detections_requires_qc(edges):
     """Test that fresh extraction results are not implicitly accepted."""
     with pytest.raises(ValueError, match="Quality control has not been run"):
@@ -95,6 +121,15 @@ def test_run_qc_records_aggregate_results(edges, qc_config):
     assert len(edges.qc_result.curvature.scores) == 2
     assert edges.qc_result.curvature.rejected_count == 0
     assert edges.qc_result.population is None
+
+
+def test_run_qc_preserves_frame_indices(edges, qc_config):
+    """Test QC does not alter source-frame identity."""
+    original_indices = [result.frame_index for result in edges.detections]
+
+    edges.run_qc(qc_config)
+
+    assert [result.frame_index for result in edges.detections] == original_indices
 
 
 def test_run_qc_can_recover_previous_curvature_rejection(extraction_config):
@@ -195,7 +230,7 @@ def test_checkpoint_round_trip_preserves_extraction_not_qc(
     extraction_config,
     qc_config,
 ):
-    """Test checkpointing preserves raw extraction state, not QC state."""
+    """Test checkpointing preserves extraction state and frame identity."""
     first = _edge(radius=10.0)
     second = _edge(radius=12.0)
     edge_results = VesicleEdges(
@@ -218,6 +253,7 @@ def test_checkpoint_round_trip_preserves_extraction_not_qc(
     assert isinstance(loaded.detections[1], EdgeDetectionFailure)
     assert loaded.detections[1].error == "bad frame"
     assert isinstance(loaded.detections[2], EdgeDetection)
+    assert [result.frame_index for result in loaded.detections] == [0, 1, 2]
     assert all(
         detection.qc.curvature_score is None
         for detection in loaded.successful_detections
@@ -226,6 +262,39 @@ def test_checkpoint_round_trip_preserves_extraction_not_qc(
         loaded.successful_detections[0].analysis_contour.r,
         first.analysis_contour.r,
     )
+
+
+def test_checkpoint_v1_load_infers_frame_indices(
+    tmp_path,
+    extraction_config,
+):
+    """Test legacy v1 checkpoints recover frame identity from stored order."""
+    edge_results = VesicleEdges(
+        extraction_config=extraction_config,
+        detections=[
+            _edge(radius=10.0),
+            EdgeDetectionFailure("bad frame"),
+            _edge(radius=12.0),
+        ],
+    )
+    current_path = tmp_path / "current.npz"
+    edge_results.save_checkpoint(current_path)
+
+    with np.load(current_path, allow_pickle=False) as checkpoint:
+        legacy_data = {
+            key: checkpoint[key].copy()
+            for key in checkpoint.files
+            if key != "frame_indices"
+        }
+    legacy_data["checkpoint_version"] = np.asarray(1)
+    legacy_path = tmp_path / "legacy_v1.npz"
+    np.savez(legacy_path, **legacy_data)
+
+    loaded = VesicleEdges.from_checkpoint(legacy_path)
+
+    assert [result.frame_index for result in loaded.detections] == [0, 1, 2]
+    assert isinstance(loaded.detections[1], EdgeDetectionFailure)
+    assert loaded.detections[1].error == "bad frame"
 
 
 def test_checkpoint_preserves_variable_native_lengths(tmp_path):

--- a/tests/unit_tests/test_vesicle_video.py
+++ b/tests/unit_tests/test_vesicle_video.py
@@ -57,6 +57,23 @@ def test_extract_edges_returns_vesicle_edges(
     assert [result.frame_index for result in edges.detections] == [0, 1]
 
 
+def test_extract_edges_propagates_source_path(extraction_config, tmp_path):
+    """Test extracted edges retain the original video path."""
+    source_path = tmp_path / "source.nd2"
+    video = VesicleVideo(
+        np.zeros((2, 200, 200)),
+        source_path=source_path,
+    )
+
+    def extractor(frame):
+        return np.full(200, 20.0), (60.0, 50.0)
+
+    edges = video.extract_edges(extractor, extraction_config)
+
+    assert video.source_path == source_path
+    assert edges.source_path == source_path
+
+
 def test_extract_edges_preserves_frame_order_after_failure(
     extraction_config,
 ):

--- a/tests/unit_tests/test_vesicle_video.py
+++ b/tests/unit_tests/test_vesicle_video.py
@@ -54,12 +54,13 @@ def test_extract_edges_returns_vesicle_edges(
         isinstance(result, EdgeDetection)
         for result in edges.detections
     )
+    assert [result.frame_index for result in edges.detections] == [0, 1]
 
 
 def test_extract_edges_preserves_frame_order_after_failure(
     extraction_config,
 ):
-    """Test that extraction failures retain their original frame position."""
+    """Test extraction failures retain source-frame identity."""
     frames = np.zeros((3, 200, 200))
     frames[1] = 1.0
     video = VesicleVideo(frames)
@@ -77,6 +78,7 @@ def test_extract_edges_preserves_frame_order_after_failure(
     assert isinstance(edges.detections[0], EdgeDetection)
     assert isinstance(edges.detections[1], EdgeDetectionFailure)
     assert isinstance(edges.detections[2], EdgeDetection)
+    assert [result.frame_index for result in edges.detections] == [0, 1, 2]
 
 
 def test_extract_edges_records_extractor_index_error(
@@ -96,7 +98,9 @@ def test_extract_edges_records_extractor_index_error(
 
     assert isinstance(edges.detections[0], EdgeDetectionFailure)
     assert edges.detections[0].error == "extractor index failure"
+    assert edges.detections[0].frame_index == 0
     assert isinstance(edges.detections[1], EdgeDetection)
+    assert edges.detections[1].frame_index == 1
 
 
 def test_extract_edges_propagates_invalid_downsampling_configuration(video):
@@ -179,11 +183,13 @@ def test_compile_edge_detection_results_preserves_and_downsamples_contour(
         r_vals,
         (60.0, 50.0),
         extraction_config,
+        frame_index=7,
     )
 
     assert edge.full_contour.origin == (50.0, 60.0)
     assert edge.full_contour.r.shape == (200,)
     assert edge.analysis_contour.r.shape == (120,)
+    assert edge.frame_index == 7
 
 
 def test_downsample_r_vals_rejects_more_samples_than_input():

--- a/vesmod/VesEdge/checkpoint_io.py
+++ b/vesmod/VesEdge/checkpoint_io.py
@@ -44,10 +44,16 @@ def save_checkpoint(
             "differ."
         )
 
-    frame_indices = np.asarray(
-        [result.frame_index for result in detections],
-        dtype=np.int64,
-    )
+    raw_frame_indices = [result.frame_index for result in detections]
+    if any(
+        isinstance(frame_index, (bool, np.bool_))
+        or not isinstance(frame_index, (int, np.integer))
+        for frame_index in raw_frame_indices
+    ):
+        raise ValueError(
+            "Cannot save a checkpoint with missing or inconsistent frame indices."
+        )
+    frame_indices = np.asarray(raw_frame_indices, dtype=np.int64)
     expected_indices = np.arange(len(detections), dtype=np.int64)
     if not np.array_equal(frame_indices, expected_indices):
         raise ValueError(

--- a/vesmod/VesEdge/checkpoint_io.py
+++ b/vesmod/VesEdge/checkpoint_io.py
@@ -15,7 +15,8 @@ from .models import (
     ImageContour,
 )
 
-CHECKPOINT_VERSION = 1
+CHECKPOINT_VERSION = 2
+_SUPPORTED_CHECKPOINT_VERSIONS = {1, CHECKPOINT_VERSION}
 _DETECTION_CODE = 1
 _FAILURE_CODE = 0
 
@@ -42,6 +43,16 @@ def save_checkpoint(
         raise ValueError(
             "Cannot save a checkpoint when full and analysis contour origins "
             "differ."
+        )
+
+    frame_indices = np.asarray(
+        [result.frame_index for result in detections],
+        dtype=np.int64,
+    )
+    expected_indices = np.arange(len(detections), dtype=np.int64)
+    if not np.array_equal(frame_indices, expected_indices):
+        raise ValueError(
+            "Cannot save a checkpoint with missing or inconsistent frame indices."
         )
 
     result_types = np.asarray(
@@ -86,6 +97,7 @@ def save_checkpoint(
             n_angular_samples,
             dtype=np.int64,
         ),
+        frame_indices=frame_indices,
         result_types=result_types,
         failure_errors=failure_errors,
         origins=origins,
@@ -113,16 +125,20 @@ def load_checkpoint(
             for key in checkpoint.files
         }
 
-    _validate_checkpoint_keys(saved_data)
+    if "checkpoint_version" not in saved_data:
+        raise ValueError(
+            "VesEdge checkpoint is missing required field(s): checkpoint_version."
+        )
     version = int(saved_data["checkpoint_version"])
-    if version != CHECKPOINT_VERSION:
+    if version not in _SUPPORTED_CHECKPOINT_VERSIONS:
         raise ValueError(
             "Unsupported VesEdge checkpoint version: "
             f"{version}."
         )
+    _validate_checkpoint_keys(saved_data, version)
 
     extraction_config = _extraction_config_from_checkpoint(saved_data)
-    detections = _detections_from_checkpoint(saved_data)
+    detections = _detections_from_checkpoint(saved_data, version)
     return extraction_config, detections
 
 
@@ -148,6 +164,7 @@ def _flatten_full_radii(
 
 def _validate_checkpoint_keys(
     checkpoint: dict[str, np.ndarray],
+    version: int,
 ) -> None:
     """Verify that a checkpoint contains all required extraction fields."""
     required_keys = {
@@ -161,6 +178,9 @@ def _validate_checkpoint_keys(
         "full_radii_offsets",
         "analysis_radii_pixels",
     }
+    if version >= 2:
+        required_keys.add("frame_indices")
+
     missing_keys = required_keys - checkpoint.keys()
     if missing_keys:
         missing = ", ".join(sorted(missing_keys))
@@ -185,9 +205,15 @@ def _extraction_config_from_checkpoint(
 
 def _detections_from_checkpoint(
     checkpoint: dict[str, np.ndarray],
+    version: int,
 ) -> list[EdgeResult]:
     """Reconstruct ordered extraction results from checkpoint arrays."""
     result_types = checkpoint["result_types"]
+    frame_indices = (
+        checkpoint["frame_indices"]
+        if version >= 2
+        else np.arange(result_types.shape[0], dtype=np.int64)
+    )
     success_count = int(
         np.count_nonzero(result_types == _DETECTION_CODE)
     )
@@ -196,6 +222,7 @@ def _detections_from_checkpoint(
     )
     _validate_checkpoint_shapes(
         checkpoint,
+        frame_indices,
         success_count,
         failure_count,
     )
@@ -205,9 +232,11 @@ def _detections_from_checkpoint(
         checkpoint["analysis_radii_pixels"],
         checkpoint["full_radii_values"],
         checkpoint["full_radii_offsets"],
+        frame_indices[result_types == _DETECTION_CODE],
     )
     return _merge_checkpoint_results(
         result_types,
+        frame_indices,
         successful,
         checkpoint["failure_errors"],
     )
@@ -215,6 +244,7 @@ def _detections_from_checkpoint(
 
 def _validate_checkpoint_shapes(
     checkpoint: dict[str, np.ndarray],
+    frame_indices: np.ndarray,
     success_count: int,
     failure_count: int,
 ) -> None:
@@ -233,6 +263,14 @@ def _validate_checkpoint_shapes(
     if result_types.ndim != 1 or not np.all(valid_codes):
         raise ValueError(
             "VesEdge checkpoint contains invalid result types."
+        )
+    expected_indices = np.arange(result_types.shape[0], dtype=np.int64)
+    if (
+        frame_indices.shape != result_types.shape
+        or not np.array_equal(frame_indices, expected_indices)
+    ):
+        raise ValueError(
+            "VesEdge checkpoint frame indices are inconsistent."
         )
     if failure_errors.shape != (failure_count,):
         raise ValueError(
@@ -268,6 +306,7 @@ def _successful_detections_from_checkpoint(
     analysis_radii: np.ndarray,
     full_values: np.ndarray,
     full_offsets: np.ndarray,
+    frame_indices: np.ndarray,
 ) -> list[EdgeDetection]:
     """Reconstruct successful detections from checkpoint arrays."""
     detections = []
@@ -288,6 +327,7 @@ def _successful_detections_from_checkpoint(
                     origin,
                     analysis_radii[index].copy(),
                 ),
+                frame_index=int(frame_indices[index]),
             )
         )
     return detections
@@ -295,6 +335,7 @@ def _successful_detections_from_checkpoint(
 
 def _merge_checkpoint_results(
     result_types: np.ndarray,
+    frame_indices: np.ndarray,
     successful: list[EdgeDetection],
     failure_errors: np.ndarray,
 ) -> list[EdgeResult]:
@@ -302,14 +343,19 @@ def _merge_checkpoint_results(
     detections: list[EdgeResult] = []
     success_index = 0
     failure_index = 0
-    for result_type in result_types:
+    for result_type, frame_index in zip(
+        result_types,
+        frame_indices,
+        strict=True,
+    ):
         if int(result_type) == _DETECTION_CODE:
             detections.append(successful[success_index])
             success_index += 1
         else:
             detections.append(
                 EdgeDetectionFailure(
-                    str(failure_errors[failure_index])
+                    str(failure_errors[failure_index]),
+                    frame_index=int(frame_index),
                 )
             )
             failure_index += 1

--- a/vesmod/VesEdge/checkpoint_io.py
+++ b/vesmod/VesEdge/checkpoint_io.py
@@ -23,6 +23,7 @@ def save_checkpoint(
     path: str | Path,
     extraction_config: EdgeExtractionConfig,
     detections: list[EdgeResult],
+    source_path: str | Path | None = None,
 ) -> None:
     """Save QC-independent extraction results to a ``.npz`` file."""
     successful = [
@@ -84,29 +85,35 @@ def save_checkpoint(
         else extraction_config.n_angular_samples
     )
 
-    np.savez(
-        Path(path).with_suffix(".npz"),
-        pixels_per_micron=np.asarray(
+    checkpoint_data = {
+        "pixels_per_micron": np.asarray(
             extraction_config.pixels_per_micron,
             dtype=float,
         ),
-        n_angular_samples=np.asarray(
+        "n_angular_samples": np.asarray(
             n_angular_samples,
             dtype=np.int64,
         ),
-        frame_indices=frame_indices,
-        result_types=result_types,
-        failure_errors=failure_errors,
-        origins=origins,
-        full_radii_values=full_radii_values,
-        full_radii_offsets=full_radii_offsets,
-        analysis_radii_pixels=analysis_radii_pixels,
+        "frame_indices": frame_indices,
+        "result_types": result_types,
+        "failure_errors": failure_errors,
+        "origins": origins,
+        "full_radii_values": full_radii_values,
+        "full_radii_offsets": full_radii_offsets,
+        "analysis_radii_pixels": analysis_radii_pixels,
+    }
+    if source_path is not None:
+        checkpoint_data["source_path"] = np.asarray(str(source_path))
+
+    np.savez(
+        Path(path).with_suffix(".npz"),
+        **checkpoint_data,
     )
 
 
 def load_checkpoint(
     path: str | Path,
-) -> tuple[EdgeExtractionConfig, list[EdgeResult]]:
+) -> tuple[EdgeExtractionConfig, list[EdgeResult], Path | None]:
     """Load QC-independent extraction results from a VesEdge checkpoint."""
     checkpoint_path = Path(path)
     if not checkpoint_path.is_file():
@@ -126,7 +133,8 @@ def load_checkpoint(
 
     extraction_config = _extraction_config_from_checkpoint(saved_data)
     detections = _detections_from_checkpoint(saved_data)
-    return extraction_config, detections
+    source_path = _source_path_from_checkpoint(saved_data)
+    return extraction_config, detections, source_path
 
 
 def _flatten_full_radii(
@@ -184,6 +192,15 @@ def _extraction_config_from_checkpoint(
             None if stored_samples == -1 else stored_samples
         ),
     )
+
+
+def _source_path_from_checkpoint(
+    checkpoint: dict[str, np.ndarray],
+) -> Path | None:
+    """Return persisted source-video provenance when present."""
+    if "source_path" not in checkpoint:
+        return None
+    return Path(str(checkpoint["source_path"].item()))
 
 
 def _detections_from_checkpoint(

--- a/vesmod/VesEdge/checkpoint_io.py
+++ b/vesmod/VesEdge/checkpoint_io.py
@@ -15,8 +15,8 @@ from .models import (
     ImageContour,
 )
 
-CHECKPOINT_VERSION = 2
-_SUPPORTED_CHECKPOINT_VERSIONS = {1, CHECKPOINT_VERSION}
+CHECKPOINT_VERSION = "1.1"
+_SUPPORTED_CHECKPOINT_VERSIONS = {"1", CHECKPOINT_VERSION}
 _DETECTION_CODE = 1
 _FAILURE_CODE = 0
 
@@ -129,7 +129,7 @@ def load_checkpoint(
         raise ValueError(
             "VesEdge checkpoint is missing required field(s): checkpoint_version."
         )
-    version = int(saved_data["checkpoint_version"])
+    version = str(saved_data["checkpoint_version"].item())
     if version not in _SUPPORTED_CHECKPOINT_VERSIONS:
         raise ValueError(
             "Unsupported VesEdge checkpoint version: "
@@ -164,7 +164,7 @@ def _flatten_full_radii(
 
 def _validate_checkpoint_keys(
     checkpoint: dict[str, np.ndarray],
-    version: int,
+    version: str,
 ) -> None:
     """Verify that a checkpoint contains all required extraction fields."""
     required_keys = {
@@ -178,7 +178,7 @@ def _validate_checkpoint_keys(
         "full_radii_offsets",
         "analysis_radii_pixels",
     }
-    if version >= 2:
+    if version == CHECKPOINT_VERSION:
         required_keys.add("frame_indices")
 
     missing_keys = required_keys - checkpoint.keys()
@@ -205,13 +205,13 @@ def _extraction_config_from_checkpoint(
 
 def _detections_from_checkpoint(
     checkpoint: dict[str, np.ndarray],
-    version: int,
+    version: str,
 ) -> list[EdgeResult]:
     """Reconstruct ordered extraction results from checkpoint arrays."""
     result_types = checkpoint["result_types"]
     frame_indices = (
         checkpoint["frame_indices"]
-        if version >= 2
+        if version == CHECKPOINT_VERSION
         else np.arange(result_types.shape[0], dtype=np.int64)
     )
     success_count = int(

--- a/vesmod/VesEdge/checkpoint_io.py
+++ b/vesmod/VesEdge/checkpoint_io.py
@@ -15,8 +15,6 @@ from .models import (
     ImageContour,
 )
 
-CHECKPOINT_VERSION = "1.1"
-_SUPPORTED_CHECKPOINT_VERSIONS = {"1", CHECKPOINT_VERSION}
 _DETECTION_CODE = 1
 _FAILURE_CODE = 0
 
@@ -26,7 +24,7 @@ def save_checkpoint(
     extraction_config: EdgeExtractionConfig,
     detections: list[EdgeResult],
 ) -> None:
-    """Save QC-independent extraction results to a versioned ``.npz`` file."""
+    """Save QC-independent extraction results to a ``.npz`` file."""
     successful = [
         result
         for result in detections
@@ -88,7 +86,6 @@ def save_checkpoint(
 
     np.savez(
         Path(path).with_suffix(".npz"),
-        checkpoint_version=np.asarray(CHECKPOINT_VERSION),
         pixels_per_micron=np.asarray(
             extraction_config.pixels_per_micron,
             dtype=float,
@@ -125,20 +122,10 @@ def load_checkpoint(
             for key in checkpoint.files
         }
 
-    if "checkpoint_version" not in saved_data:
-        raise ValueError(
-            "VesEdge checkpoint is missing required field(s): checkpoint_version."
-        )
-    version = str(saved_data["checkpoint_version"].item())
-    if version not in _SUPPORTED_CHECKPOINT_VERSIONS:
-        raise ValueError(
-            "Unsupported VesEdge checkpoint version: "
-            f"{version}."
-        )
-    _validate_checkpoint_keys(saved_data, version)
+    _validate_checkpoint_keys(saved_data)
 
     extraction_config = _extraction_config_from_checkpoint(saved_data)
-    detections = _detections_from_checkpoint(saved_data, version)
+    detections = _detections_from_checkpoint(saved_data)
     return extraction_config, detections
 
 
@@ -164,11 +151,9 @@ def _flatten_full_radii(
 
 def _validate_checkpoint_keys(
     checkpoint: dict[str, np.ndarray],
-    version: str,
 ) -> None:
     """Verify that a checkpoint contains all required extraction fields."""
     required_keys = {
-        "checkpoint_version",
         "pixels_per_micron",
         "n_angular_samples",
         "result_types",
@@ -178,8 +163,6 @@ def _validate_checkpoint_keys(
         "full_radii_offsets",
         "analysis_radii_pixels",
     }
-    if version == CHECKPOINT_VERSION:
-        required_keys.add("frame_indices")
 
     missing_keys = required_keys - checkpoint.keys()
     if missing_keys:
@@ -205,14 +188,12 @@ def _extraction_config_from_checkpoint(
 
 def _detections_from_checkpoint(
     checkpoint: dict[str, np.ndarray],
-    version: str,
 ) -> list[EdgeResult]:
     """Reconstruct ordered extraction results from checkpoint arrays."""
     result_types = checkpoint["result_types"]
-    frame_indices = (
-        checkpoint["frame_indices"]
-        if version == CHECKPOINT_VERSION
-        else np.arange(result_types.shape[0], dtype=np.int64)
+    frame_indices = checkpoint.get(
+        "frame_indices",
+        np.arange(result_types.shape[0], dtype=np.int64),
     )
     success_count = int(
         np.count_nonzero(result_types == _DETECTION_CODE)

--- a/vesmod/VesEdge/models.py
+++ b/vesmod/VesEdge/models.py
@@ -122,11 +122,16 @@ class EdgeDetection:
         as `full_contour`.
     qc : EdgeQC
         Quality-control information associated with this detection.
+    frame_index : int | None
+        Zero-based source video frame index. None only for legacy/manually
+        constructed results that have not yet been associated with a
+        :class:`VesicleEdges` trajectory.
     """
 
     full_contour: ImageContour
     analysis_contour: ImageContour
     qc: EdgeQC = field(default_factory=EdgeQC)
+    frame_index: int | None = field(default=None, kw_only=True)
 
 
 @dataclass(frozen=True)
@@ -138,9 +143,14 @@ class EdgeDetectionFailure:
     ----------
     error : str
         Error message produced while attempting edge extraction.
+    frame_index : int | None
+        Zero-based source video frame index. None only for legacy/manually
+        constructed results that have not yet been associated with a
+        :class:`VesicleEdges` trajectory.
     """
 
     error: str
+    frame_index: int | None = field(default=None, kw_only=True)
 
 
 EdgeResult = EdgeDetection | EdgeDetectionFailure

--- a/vesmod/VesEdge/vesicle_edges.py
+++ b/vesmod/VesEdge/vesicle_edges.py
@@ -46,7 +46,7 @@ class VesicleEdges:
 
     def __post_init__(self) -> None:
         """Validate extraction results stored on the object."""
-        self._normalize_frame_indices()
+        self._infer_frame_indices()
         self._validate_detection_lengths()
 
     @property
@@ -192,8 +192,8 @@ class VesicleEdges:
             max_minor_fraction=config.max_minor_population_fraction,
         )
 
-    def _normalize_frame_indices(self) -> None:
-        """Fill legacy frame indices and verify stored source-frame identity."""
+    def _infer_frame_indices(self) -> None:
+        """Infer missing frame indices and verify stored source-frame identity."""
         for expected_index, result in enumerate(self.detections):
             if result.frame_index is None:
                 if isinstance(result, EdgeDetection):

--- a/vesmod/VesEdge/vesicle_edges.py
+++ b/vesmod/VesEdge/vesicle_edges.py
@@ -35,10 +35,13 @@ class VesicleEdges:
         Configuration used to construct the stored analysis contours.
     detections : list[EdgeResult]
         Ordered extraction result corresponding to each source video frame.
+    source_path : str | Path | None
+        Path to the original source video, when known.
     """
 
     extraction_config: EdgeExtractionConfig
     detections: list[EdgeResult]
+    source_path: str | Path | None = None
     qc_result: VesicleQCResult | None = field(
         default=None,
         init=False,
@@ -46,6 +49,8 @@ class VesicleEdges:
 
     def __post_init__(self) -> None:
         """Validate extraction results stored on the object."""
+        if self.source_path is not None:
+            self.source_path = Path(self.source_path)
         self._infer_frame_indices()
         self._validate_detection_lengths()
 
@@ -253,13 +258,15 @@ class VesicleEdges:
             path,
             self.extraction_config,
             self.detections,
+            source_path=self.source_path,
         )
 
     @classmethod
     def from_checkpoint(cls, path: str | Path) -> "VesicleEdges":
         """Restore extraction results from a VesEdge checkpoint without QC."""
-        extraction_config, detections = load_checkpoint(path)
+        extraction_config, detections, source_path = load_checkpoint(path)
         return cls(
             extraction_config=extraction_config,
             detections=detections,
+            source_path=source_path,
         )

--- a/vesmod/VesEdge/vesicle_edges.py
+++ b/vesmod/VesEdge/vesicle_edges.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import numpy as np
@@ -16,6 +16,7 @@ from .edge_filtering import check_curvature, check_edge_populations
 from .models import (
     CurvatureQCResult,
     EdgeDetection,
+    EdgeDetectionFailure,
     EdgePopulationResult,
     EdgeQC,
     EdgeResult,
@@ -45,6 +46,7 @@ class VesicleEdges:
 
     def __post_init__(self) -> None:
         """Validate extraction results stored on the object."""
+        self._normalize_frame_indices()
         self._validate_detection_lengths()
 
     @property
@@ -189,6 +191,26 @@ class VesicleEdges:
             bic_threshold=config.population_bic_threshold,
             max_minor_fraction=config.max_minor_population_fraction,
         )
+
+    def _normalize_frame_indices(self) -> None:
+        """Fill legacy frame indices and verify stored source-frame identity."""
+        for expected_index, result in enumerate(self.detections):
+            if result.frame_index is None:
+                if isinstance(result, EdgeDetection):
+                    result.frame_index = expected_index
+                elif isinstance(result, EdgeDetectionFailure):
+                    self.detections[expected_index] = replace(
+                        result,
+                        frame_index=expected_index,
+                    )
+                continue
+
+            if result.frame_index != expected_index:
+                raise ValueError(
+                    "Edge result frame_index must match its source-frame "
+                    f"position: expected {expected_index}, got "
+                    f"{result.frame_index}."
+                )
 
     def _validate_detection_lengths(self) -> None:
         """Verify successful detections have consistent analysis lengths."""

--- a/vesmod/VesEdge/vesicle_video.py
+++ b/vesmod/VesEdge/vesicle_video.py
@@ -26,16 +26,27 @@ from .vesicle_video_utils import downsample_to_new_indices
 
 @dataclass
 class VesicleVideo:
-    """Raw image frames for one vesicle trajectory."""
+    """Raw image frames for one vesicle trajectory.
+
+    Parameters
+    ----------
+    frames : np.ndarray
+        Three-dimensional array containing the source image frames.
+    source_path : str | Path | None
+        Path to the original source video, when known.
+    """
 
     frames: np.ndarray
+    source_path: str | Path | None = None
 
     def __post_init__(self) -> None:
-        """Validate raw image frames."""
+        """Validate raw image frames and source provenance."""
         if not isinstance(self.frames, np.ndarray):
             raise TypeError("frames must be a numpy ndarray.")
         if self.frames.ndim != 3:
             raise IndexError("frames must be a 3D array.")
+        if self.source_path is not None:
+            self.source_path = Path(self.source_path)
 
     def extract_edges(
         self,
@@ -127,6 +138,7 @@ class VesicleVideo:
         return VesicleEdges(
             extraction_config=extraction_config,
             detections=detections,
+            source_path=self.source_path,
         )
 
     def make_vesicle_gif(

--- a/vesmod/VesEdge/vesicle_video.py
+++ b/vesmod/VesEdge/vesicle_video.py
@@ -60,7 +60,7 @@ class VesicleVideo:
             samples returned by the extractor for a frame.
         """
         detections: list[EdgeResult] = []
-        for frame in self.frames:
+        for frame_index, frame in enumerate(self.frames):
             try:
                 r_vals, vesicle_center = extractor_func(frame)
                 self._validate_extractor_results(r_vals)
@@ -68,7 +68,12 @@ class VesicleVideo:
             # should be recorded without aborting the remaining trajectory.
             # pylint: disable-next=broad-exception-caught
             except Exception as error:  # noqa: BLE001
-                detections.append(EdgeDetectionFailure(str(error)))
+                detections.append(
+                    EdgeDetectionFailure(
+                        str(error),
+                        frame_index=frame_index,
+                    )
+                )
                 continue
 
             try:
@@ -76,18 +81,29 @@ class VesicleVideo:
                     r_vals,
                     vesicle_center,
                     extraction_config,
+                    frame_index=frame_index,
                 )
             except IndexError as error:
                 n_samples = extraction_config.n_angular_samples
                 if n_samples is not None and n_samples > r_vals.shape[0]:
                     raise
-                detections.append(EdgeDetectionFailure(str(error)))
+                detections.append(
+                    EdgeDetectionFailure(
+                        str(error),
+                        frame_index=frame_index,
+                    )
+                )
                 continue
             # Compilation can still fail on malformed extractor output; retain
             # the established per-frame failure behavior for those cases.
             # pylint: disable-next=broad-exception-caught
             except Exception as error:  # noqa: BLE001
-                detections.append(EdgeDetectionFailure(str(error)))
+                detections.append(
+                    EdgeDetectionFailure(
+                        str(error),
+                        frame_index=frame_index,
+                    )
+                )
                 continue
 
             detections.append(detected_edge)
@@ -181,6 +197,8 @@ class VesicleVideo:
         r_vals: NDArray[np.float64],
         vesicle_center: tuple[float, float],
         extraction_config: EdgeExtractionConfig,
+        *,
+        frame_index: int | None = None,
     ) -> EdgeDetection:
         """Build a successful detection from raw extractor output."""
         center = (vesicle_center[1], vesicle_center[0])
@@ -197,6 +215,7 @@ class VesicleVideo:
         return EdgeDetection(
             full_contour,
             analysis_contour,
+            frame_index=frame_index,
         )
 
     @staticmethod


### PR DESCRIPTION
## Description
Preserve the identity and provenance of the source video frame associated with each edge-extraction result.

Previously, `VesicleEdges.detections` preserved source-frame identity only implicitly through list position. This works while the complete result list remains intact, but successful detections can be separated from failures during QC, filtering, analysis, or persistence. This PR adds a `frame_index` to both `EdgeDetection` and `EdgeDetectionFailure` so each result retains an explicit link to its original video frame.

`VesicleVideo` now also stores an optional `source_path` identifying the original source video, such as the `.nd2` acquisition file. `VesicleVideo.extract_edges()` propagates that path to the resulting `VesicleEdges`, allowing a saved QC failure to be traced back to both the original video and the exact frame.

Checkpoint files now explicitly store `frame_indices` and, when known, `source_path`. When loading an older checkpoint that lacks either field, VesEdge uses capability checks: frame indices are inferred from stored result ordering and source provenance is left as `None`. No checkpoint version field is required.

Closes #69.

## Usage Changes
`VesicleVideo` accepts an optional source path:

```python
video = VesicleVideo(
    frames,
    source_path="/path/to/original.nd2",
)
```

The path is converted to a `Path` and propagated automatically when edges are extracted:

```python
edges = video.extract_edges(extractor, extraction_config)
assert edges.source_path == video.source_path
```

`EdgeDetection` and `EdgeDetectionFailure` now expose a `frame_index` attribute. Results produced by `VesicleVideo.extract_edges()` receive this automatically.

Existing constructors remain valid:

```python
EdgeDetection(full_contour, analysis_contour)
EdgeDetectionFailure("error message")
```

A frame index can also be supplied explicitly as a keyword argument:

```python
EdgeDetection(full_contour, analysis_contour, frame_index=42)
EdgeDetectionFailure("error message", frame_index=42)
```

New checkpoints explicitly store `frame_indices` and store `source_path` when one is available. Existing checkpoints without either field still load: frame indices are inferred from result ordering and `source_path` is `None`.

This makes downstream QC reporting able to identify a failed result by both source acquisition and frame:

```python
edges.source_path
detection.frame_index
detection.qc.flags
```

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Add source `frame_index` to successful and failed edge-extraction results
- [x] Assign source frame indices during `VesicleVideo.extract_edges()`
- [x] Add optional original-video `source_path` provenance to `VesicleVideo`
- [x] Propagate source provenance from `VesicleVideo` to `VesicleEdges`
- [x] Preserve backwards compatibility for existing result and video constructors
- [x] Infer missing frame indices when constructing `VesicleEdges`
- [x] Validate explicitly supplied frame indices against result ordering
- [x] Preserve frame identity through QC
- [x] Persist frame indices and source-video provenance in extraction checkpoints
- [x] Load older checkpoints by checking for optional fields rather than checkpoint versions
- [x] Add regression tests for extraction failures and source-frame identity
- [x] Add tests for source-path propagation and checkpoint round-trip
- [x] Add checkpoint compatibility tests for missing `frame_indices` and `source_path`

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] New configuration parameters are documented (Usage changes above)
- [x] Changes propagated to all notebooks

## Review checklist (Reviewer)
- [ ] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] All notebooks still function correctly

## Status
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source video path and frame-index tracking to vesicle extraction results.
  * Preserved frame identity for both successful detections and extraction failures.
  * Checkpoints now retain provenance and frame indices, with support for older checkpoint formats.

* **Bug Fixes**
  * Added validation to detect inconsistent or non-sequential frame indices.
  * Improved checkpoint loading and result merging while preserving frame identity.

* **Tests**
  * Expanded coverage for frame tracking, provenance persistence, legacy checkpoints, and extraction errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->