### PR TITLE
71 dynamic q range selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 VesMod is a Python package for extracting membrane contours from microscopy videos of giant unilamellar vesicles (GUVs) and estimating membrane bending rigidity from thermal shape fluctuations.
 
-VesEdge separates image-dependent edge extraction from quality control so the same extracted contours can be evaluated under multiple QC configurations without rerunning image processing.
+VesEdge separates image-dependent edge extraction from quality control so the same extracted contours can be evaluated under multiple QC configurations without rerunning image processing. EdgeMod separates the measured fluctuation spectrum from the scientific configuration used to fit that spectrum, allowing fixed and dynamically selected Fourier-mode ranges to be compared on the same data.
 
 ---
 
@@ -41,7 +41,12 @@ Features include:
 * Fourier analysis of contour fluctuations
 * Estimation of membrane bending modulus (kC)
 * Optional estimation of membrane tension (σ)
-* JSON export of analysis results
+* Config-driven physical fitting through `SpectrumFitConfig`
+* Fixed Fourier-mode fitting with user-defined bounds
+* Optional dynamic selection of a trustworthy q range from q^-3 scaling
+* Rejection of spectra that do not contain an acceptable q^-3 regime
+* Retention of multiple fit results on the same `Spectrum`
+* JSON export of fit values, selected q bounds, fit configuration, and range-selection diagnostics
 * Batch processing of contour datasets
 
 Detailed documentation:
@@ -150,18 +155,32 @@ Keeping each QC configuration in its own directory makes the analysis provenance
 
 ### 4. Analyze each QC result with EdgeMod
 
+The default EdgeMod CLI uses the historical fixed q range, q = 3--7:
+
 ```bash
 edgemod ./results/qc_standard
 edgemod ./results/qc_permissive
 ```
 
-The resulting EdgeMod outputs can then be compared together with each directory's `vesedge_qc.json` and `qc_summary.csv` when reporting how sensitive the result is to QC choices.
+Dynamic q-range selection can be enabled explicitly. The selector only searches inside the configured candidate interval and requires explicit acceptance thresholds:
+
+```bash
+edgemod ./results/qc_standard \
+    --dynamic-range \
+    --lower-fitting-bound 3 \
+    --upper-fitting-bound 20 \
+    --min-modes 5 \
+    --slope-tolerance 0.2 \
+    --max-log-rmse 0.1
+```
+
+Fixed output is written as `<input>.json`; dynamic output is written as `<input>.dynamic.json`, so the two analyses can be run on the same contour files without overwriting one another.
 
 ---
 
 ## Equivalent Python Workflow
 
-The Python API exposes the same separation:
+The Python API exposes the same separation between extraction, QC, and spectrum fitting.
 
 ```python
 from vesmod.VesEdge import (
@@ -201,6 +220,37 @@ edges.save_edge_to_npy("sample.npy")
 
 After a completed QC run, `edges.qc_result` contains the configuration and results from the enabled QC stages. Per-detection QC annotations remain available on each `EdgeDetection.qc`.
 
+Fit the accepted contours with EdgeMod:
+
+```python
+from vesmod.EdgeMod import (
+    FixedFitRangeSelector,
+    QMinusThreeFitRangeSelector,
+    Spectrum,
+    SpectrumFitConfig,
+)
+
+spectrum = Spectrum("sample.npy")
+
+fixed_config = SpectrumFitConfig(
+    range_selector=FixedFitRangeSelector(3, 8),
+)
+fixed_fit = spectrum.extract_kc_from_fit(fixed_config)
+
+dynamic_config = SpectrumFitConfig(
+    range_selector=QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=20,
+        min_modes=5,
+        slope_tolerance=0.2,
+        max_log_rmse=0.1,
+    ),
+)
+dynamic_fit = spectrum.extract_kc_from_fit(dynamic_config)
+```
+
+Both results remain available in `spectrum.fit_results`. Each `SpectrumFit` records the actual q bounds used and the full `SpectrumFitConfig`, so fixed and dynamic analyses can be compared without one overwriting the other.
+
 ---
 
 ## Data Products
@@ -212,7 +262,8 @@ After a completed QC run, `edges.qc_result` contains the configuration and resul
 | `.npy` | Accepted contour radii for one QC configuration, ready for EdgeMod |
 | `vesedge_qc.json` | QC configuration and source path for one QC batch |
 | `qc_summary.csv` | Per-video QC counts and accepted fractions for one QC batch |
-| `.json` | EdgeMod spectrum/fitting output |
+| `.json` | EdgeMod fixed-range spectrum/fitting output |
+| `.dynamic.json` | EdgeMod dynamically selected-range spectrum/fitting output |
 
 ---
 

--- a/docs/EdgeMod_CLI_README.md
+++ b/docs/EdgeMod_CLI_README.md
@@ -1,6 +1,13 @@
 # EdgeMod CLI
 
-EdgeMod is a command-line tool for fitting membrane bending moduli from vesicle contour data. It reads one or more NumPy `.npy` edge files, computes fluctuation spectra, fits membrane mechanical parameters, and writes the results to JSON files for downstream analysis.
+EdgeMod fits membrane mechanical parameters from vesicle contour trajectories. It reads one or more NumPy `.npy` edge files, computes fluctuation spectra, selects the Fourier modes used for the physical fit, and writes JSON results for downstream analysis.
+
+EdgeMod supports two q-range strategies:
+
+* **Fixed fitting** uses an explicitly configured lower-inclusive, upper-exclusive q interval.
+* **Dynamic fitting** searches within a trusted q interval for the longest contiguous range consistent with q^-3 scaling and rejects the spectrum if no acceptable range is found.
+
+Fixed fitting remains the default CLI behavior.
 
 ## Features
 
@@ -9,9 +16,12 @@ EdgeMod is a command-line tool for fitting membrane bending moduli from vesicle 
 * Automatic fluctuation spectrum calculation
 * Fitting of membrane bending modulus ($k_C$)
 * Optional fitting of membrane surface tension ($\sigma$)
-* Configurable Fourier fitting range
+* Fixed or dynamically selected Fourier fitting ranges
+* Explicit dynamic q^-3 acceptance criteria
+* Rejection of spectra with no trustworthy q^-3 regime
 * Configurable spherical harmonic summation limit
-* JSON output for downstream analysis
+* JSON output containing fit values, q bounds, configuration, and selection diagnostics
+* Separate fixed and dynamic output filenames for direct comparison
 
 ---
 
@@ -35,13 +45,22 @@ edgemod --help
 
 ## Quick Start
 
-Fit membrane mechanical parameters from a single contour file:
+Fit membrane mechanical parameters from a single contour file using the default fixed q range:
 
 ```bash
 edgemod sample.npy
 ```
 
-This performs a fit using the default fitting parameters and writes:
+The default fit uses:
+
+```text
+q = 3, 4, 5, 6, 7
+lmax = 500
+free sigma = True
+temperature = 295 K
+```
+
+and writes:
 
 ```text
 sample.json
@@ -68,9 +87,7 @@ The recommended input is a contour file produced by `vesedge qc`:
 sample.npy
 ```
 
-Each row represents one accepted video frame and each column represents one angular sample along the vesicle contour.
-
-The expected array shape is:
+Each row represents one accepted video frame and each column represents one angular sample along the vesicle contour. The expected shape is:
 
 ```python
 (n_frames, n_theta)
@@ -81,36 +98,160 @@ where:
 * `n_frames` is the number of accepted contour measurements
 * `n_theta` is the number of angular samples per contour
 
-For example:
-
-```python
-import numpy as np
-
-edges = np.load("sample.npy")
-print(edges.shape)
-
-# (250, 120)
-```
-
-In this example, the file contains 250 accepted contours, each sampled at 120 angular positions.
-
 Distances should be stored in microns. VesEdge `.npy` output contains only contours that passed the selected QC configuration and is directly suitable as EdgeMod CLI input.
 
-When comparing QC configurations, keep each set of `.npy` files in its own directory and run EdgeMod separately on each directory. The corresponding `vesedge_qc.json` and `qc_summary.csv` files document which QC settings produced each analysis input.
+When comparing VesEdge QC configurations, keep each set of `.npy` files in its own directory and run EdgeMod separately on each directory. The corresponding `vesedge_qc.json` and `qc_summary.csv` files document which QC settings produced each analysis input.
 
 ---
 
-## Command Line Interface Arguments
+## Fixed q-Range Fitting
 
-### File Selection Options
+Fixed fitting is the default.
 
-#### Single file
+```bash
+edgemod sample.npy \
+    --lower-fitting-bound 3 \
+    --upper-fitting-bound 8
+```
+
+The lower bound is inclusive and the upper bound is exclusive, so the example above fits:
+
+```text
+q = 3, 4, 5, 6, 7
+```
+
+### `--lower-fitting-bound`
+
+Lowest Fourier mode included in a fixed fit.
+
+Default:
+
+```text
+3
+```
+
+### `--upper-fitting-bound`
+
+First Fourier mode excluded from a fixed fit.
+
+Default:
+
+```text
+8
+```
+
+---
+
+## Dynamic q-Range Selection
+
+Dynamic fitting is enabled with:
+
+```bash
+--dynamic-range
+```
+
+The configured lower and upper fitting bounds become the **trusted search interval**. EdgeMod searches only within that interval; it does not search high-q or very-low-q regions outside the analyst-approved domain.
+
+For example:
+
+```bash
+edgemod sample.npy \
+    --dynamic-range \
+    --lower-fitting-bound 3 \
+    --upper-fitting-bound 20 \
+    --min-modes 5 \
+    --slope-tolerance 0.2 \
+    --max-log-rmse 0.1
+```
+
+The selector considers contiguous integer-q windows within `3 <= q < 20`. Each candidate window is evaluated in log space using:
+
+1. the fitted log-log power-law slope, which must be sufficiently close to -3; and
+2. the RMSE to a fixed q^-3 model, which must be sufficiently small.
+
+Among accepted candidates, the longest range is preferred. If no candidate satisfies the configured criteria, EdgeMod raises a `ValueError` and does not run the physical HSS97 fit.
+
+### `--min-modes`
+
+Minimum number of consecutive integer q modes required in an accepted dynamic range.
+
+There is no default when dynamic selection is enabled. This must be provided explicitly.
+
+### `--slope-tolerance`
+
+Maximum allowed absolute deviation of the fitted log-log slope from -3.
+
+For example:
+
+```text
+--slope-tolerance 0.2
+```
+
+accepts slopes between -3.2 and -2.8, provided the RMSE criterion is also satisfied.
+
+There is no default when dynamic selection is enabled.
+
+### `--max-log-rmse`
+
+Maximum allowed root-mean-square residual to the best-amplitude fixed q^-3 model in natural-log space.
+
+There is no default when dynamic selection is enabled.
+
+The three dynamic acceptance parameters are intentionally explicit because appropriate thresholds are analysis decisions rather than universal constants.
+
+---
+
+## Physical Fit Parameters
+
+### `--lmax`
+
+Maximum spherical harmonic index used when evaluating the theoretical fluctuation spectrum.
+
+```bash
+edgemod sample.npy --lmax 500
+```
+
+Default:
+
+```text
+500
+```
+
+### `--fixed-sigma`
+
+By default, EdgeMod fits both bending modulus and reduced surface tension. Use:
+
+```bash
+edgemod sample.npy --fixed-sigma
+```
+
+to disable free-sigma fitting.
+
+### `--temperature`
+
+Experimental temperature in Kelvin, used when converting the fitted reduced tension into surface tension.
+
+```bash
+edgemod sample.npy --temperature 310
+```
+
+Default:
+
+```text
+295
+```
+
+---
+
+## File Selection Options
+
+### Single file
 
 ```bash
 edgemod sample.npy
 ```
 
-#### Directory
+### Directory
 
 ```bash
 edgemod ./edges
@@ -122,9 +263,7 @@ When `INPUT_PATH` is a directory, EdgeMod processes files matching:
 *.npy
 ```
 
-in that directory.
-
-#### Recursive directory search
+### Recursive directory search
 
 ```bash
 edgemod ./edges --recursive
@@ -138,120 +277,6 @@ With `--recursive`, EdgeMod processes files matching:
 
 ---
 
-### Fourier Mode Fitting Range
-
-#### `--lower-fitting-bound`
-
-```bash
-edgemod sample.npy --lower-fitting-bound 3
-```
-
-Lowest Fourier mode included in the fit.
-
-Default:
-
-```text
-3
-```
-
-#### `--upper-fitting-bound`
-
-```bash
-edgemod sample.npy --upper-fitting-bound 8
-```
-
-First Fourier mode excluded from the fit.
-
-For example:
-
-```text
-lower = 3
-upper = 8
-```
-
-fits modes:
-
-```text
-q = 3, 4, 5, 6, 7
-```
-
-Default:
-
-```text
-8
-```
-
----
-
-### Spherical Harmonic Summation
-
-#### `--lmax`
-
-```bash
-edgemod sample.npy --lmax 500
-```
-
-Maximum spherical harmonic index used when evaluating the theoretical fluctuation spectrum.
-
-Larger values increase computational cost but may improve convergence in some situations.
-
-Default:
-
-```text
-500
-```
-
----
-
-### Surface Tension Treatment
-
-#### Free surface tension fit (default)
-
-By default, EdgeMod fits both:
-
-```text
-kC
-sigma
-```
-
-as free parameters.
-
-#### `--fixed-sigma`
-
-```bash
-edgemod sample.npy --fixed-sigma
-```
-
-Use a fixed-surface-tension model in which only the bending modulus is optimized.
-
-Default:
-
-```text
-False
-```
-
----
-
-### Temperature
-
-#### `--temperature`
-
-```bash
-edgemod sample.npy --temperature 295
-```
-
-Experimental temperature in Kelvin.
-
-The value is used when converting between thermal energy and membrane mechanical parameters.
-
-Default:
-
-```text
-295
-```
-
----
-
 ## Output Files
 
 For an input file:
@@ -260,35 +285,132 @@ For an input file:
 sample.npy
 ```
 
-EdgeMod writes:
+fixed fitting writes:
 
 ```text
 sample.json
 ```
 
-### JSON Output
+and dynamic fitting writes:
 
-The JSON file contains the spectrum metadata and fitted membrane mechanical parameters.
-
-Load the output with:
-
-```python
-import json
-
-with open("sample.json") as f:
-    results = json.load(f)
+```text
+sample.dynamic.json
 ```
 
-The exact fields may vary depending on the fitting options used and the version of EdgeMod.
+This naming allows the same contour file to be analyzed with fixed and dynamic fitting without the second CLI run overwriting the first.
+
+### JSON Output
+
+The JSON contains the spectrum, latest fit values, and retained fit records. Each retained `SpectrumFit` records:
+
+* fitted `kC`
+* fitted surface tension
+* actual lower-inclusive and upper-exclusive q bounds used for the physical fit
+* the `SpectrumFitConfig` used for that fit
+* the range-selector type and parameters
+* range-selection diagnostics when applicable
+
+Dynamic selection diagnostics include the selected or best rejected range, fitted slope, log-space RMSE, acceptance state, and rejection reason.
+
+---
+
+## Python API
+
+Scientific fitting parameters are grouped in `SpectrumFitConfig` rather than passed individually to `Spectrum.extract_kc_from_fit()`.
+
+### Fixed fitting
+
+```python
+from vesmod.EdgeMod import (
+    FixedFitRangeSelector,
+    Spectrum,
+    SpectrumFitConfig,
+)
+
+spectrum = Spectrum("sample.npy")
+config = SpectrumFitConfig(
+    lmax=500,
+    free_sigma=True,
+    temperature=295.0,
+    range_selector=FixedFitRangeSelector(
+        lower_bound=3,
+        upper_bound=8,
+    ),
+)
+
+fit = spectrum.extract_kc_from_fit(config)
+print(fit.kC, fit.surface_tension)
+```
+
+Calling `extract_kc_from_fit()` without a config is equivalent to the historical default fixed fit:
+
+```python
+fit = spectrum.extract_kc_from_fit()
+```
+
+### Dynamic fitting
+
+```python
+from vesmod.EdgeMod import (
+    QMinusThreeFitRangeSelector,
+    SpectrumFitConfig,
+)
+
+config = SpectrumFitConfig(
+    range_selector=QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=20,
+        min_modes=5,
+        slope_tolerance=0.2,
+        max_log_rmse=0.1,
+    ),
+)
+
+dynamic_fit = spectrum.extract_kc_from_fit(config)
+```
+
+### Compare fixed and dynamic fits
+
+Multiple successful fits are retained on the same `Spectrum`:
+
+```python
+fixed_fit = spectrum.extract_kc_from_fit(fixed_config)
+dynamic_fit = spectrum.extract_kc_from_fit(dynamic_config)
+
+print(fixed_fit.kC)
+print(dynamic_fit.kC)
+print(spectrum.fit_results)
+```
+
+`Spectrum.kC` and `Spectrum.surface_tension` remain compatibility attributes containing the most recent successful fit values. The durable per-fit record is `SpectrumFit`.
 
 ---
 
 ## Example Workflows
 
-### Analyze a single vesicle
+### Analyze a single vesicle with fixed bounds
 
 ```bash
 edgemod sample.npy
+```
+
+### Analyze the same vesicle with dynamic range selection
+
+```bash
+edgemod sample.npy \
+    --dynamic-range \
+    --lower-fitting-bound 3 \
+    --upper-fitting-bound 20 \
+    --min-modes 5 \
+    --slope-tolerance 0.2 \
+    --max-log-rmse 0.1
+```
+
+After both commands, both files are available:
+
+```text
+sample.json
+sample.dynamic.json
 ```
 
 ### Analyze every vesicle in one VesEdge QC result
@@ -318,26 +440,6 @@ edgemod ./results/qc_permissive
 edgemod ./edges --recursive
 ```
 
-### Use a different fitting range
-
-```bash
-edgemod sample.npy \
-    --lower-fitting-bound 4 \
-    --upper-fitting-bound 10
-```
-
-### Use a different temperature
-
-```bash
-edgemod sample.npy --temperature 310
-```
-
-### Fit only the bending modulus
-
-```bash
-edgemod sample.npy --fixed-sigma
-```
-
 ---
 
 ## Troubleshooting
@@ -355,23 +457,39 @@ Check that:
 
 This occurs when `INPUT_PATH` is a file, but its suffix is not `.npy`.
 
+### Dynamic range selection requires ...
+
+When `--dynamic-range` is supplied, all of the following must also be supplied:
+
+```text
+--min-modes
+--slope-tolerance
+--max-log-rmse
+```
+
+### `No trusted q range satisfied the q^-3 scaling criteria.`
+
+The spectrum did not contain a contiguous q range inside the trusted search interval that met both dynamic acceptance criteria. Possible responses include:
+
+* inspect the spectrum for whether a q^-3 regime is present at all;
+* confirm that the trusted q interval is scientifically appropriate;
+* inspect whether the apparent q^-3 region is too short to satisfy `--min-modes`;
+* evaluate the chosen tolerances using representative accepted and rejected spectra.
+
+Do not automatically expand the search into untrusted high-q or very-low-q regions simply to force acceptance.
+
 ### Fits produce unexpected values
 
 Potential causes include:
 
 * poor contour quality in the input `.npy` file
-* an inappropriate Fourier fitting range
+* an inappropriate fixed fitting range
+* a dynamic selector accepting an unintended q region
 * too few accepted contour measurements
 * temperature values inconsistent with the experiment
 * sensitivity of the result to the selected VesEdge QC configuration
 
-Inspect the contour data and `qc_summary.csv`, compare alternate QC configurations when appropriate, and consider adjusting:
-
-```text
---lower-fitting-bound
---upper-fitting-bound
---lmax
-```
+Inspect the contour data, the spectrum, the selected q bounds, and `qc_summary.csv`. When appropriate, compare fixed and dynamic fits on the same spectrum.
 
 ---
 

--- a/docs/EdgeMod_CLI_README.md
+++ b/docs/EdgeMod_CLI_README.md
@@ -169,7 +169,7 @@ The selector considers contiguous integer-q windows within `3 <= q < 20`. Each c
 1. the fitted log-log power-law slope, which must be sufficiently close to -3; and
 2. the RMSE to a fixed q^-3 model, which must be sufficiently small.
 
-Among accepted candidates, the longest range is preferred. If no candidate satisfies the configured criteria, EdgeMod raises a `ValueError` and does not run the physical HSS97 fit.
+Among accepted candidates, the longest range is preferred. If no candidate satisfies the configured criteria, EdgeMod does not run the physical HSS97 fit. The CLI writes the rejection diagnostics to the dynamic JSON output and then raises `ValueError`.
 
 ### `--min-modes`
 
@@ -197,7 +197,7 @@ Maximum allowed root-mean-square residual to the best-amplitude fixed q^-3 model
 
 There is no default when dynamic selection is enabled.
 
-The three dynamic acceptance parameters are intentionally explicit because appropriate thresholds are analysis decisions rather than universal constants.
+The three dynamic acceptance parameters are intentionally explicit because appropriate thresholds are analysis decisions rather than universal constants. Both tolerance values must be finite and non-negative.
 
 ---
 
@@ -229,7 +229,7 @@ to disable free-sigma fitting.
 
 ### `--temperature`
 
-Experimental temperature in Kelvin, used when converting the fitted reduced tension into surface tension.
+Experimental temperature in Kelvin, used when converting the fitted reduced tension into surface tension. Temperature must be finite and positive.
 
 ```bash
 edgemod sample.npy --temperature 310
@@ -301,16 +301,16 @@ This naming allows the same contour file to be analyzed with fixed and dynamic f
 
 ### JSON Output
 
-The JSON contains the spectrum, latest fit values, and retained fit records. Each retained `SpectrumFit` records:
+The JSON contains the spectrum, latest successful fit values, and retained fit records. Each retained `SpectrumFit` records:
 
 * fitted `kC`
 * fitted surface tension
 * actual lower-inclusive and upper-exclusive q bounds used for the physical fit
 * the `SpectrumFitConfig` used for that fit
 * the range-selector type and parameters
-* range-selection diagnostics when applicable
+* range-selection diagnostics
 
-Dynamic selection diagnostics include the selected or best rejected range, fitted slope, log-space RMSE, acceptance state, and rejection reason.
+If dynamic range selection rejects the spectrum, no new `SpectrumFit` is created. The CLI still writes `sample.dynamic.json` before re-raising the error. In that failure JSON, the top-level `fit_range_selection` field contains the best rejected range when one was evaluable, fitted slope, log-space RMSE, `accepted: false`, and the rejection reason. For a fresh CLI `Spectrum`, `kC` and `surface_tension` remain `null` because no physical fit succeeded.
 
 ---
 
@@ -328,7 +328,7 @@ from vesmod.EdgeMod import (
 )
 
 spectrum = Spectrum("sample.npy")
-config = SpectrumFitConfig(
+fixed_config = SpectrumFitConfig(
     lmax=500,
     free_sigma=True,
     temperature=295.0,
@@ -338,8 +338,8 @@ config = SpectrumFitConfig(
     ),
 )
 
-fit = spectrum.extract_kc_from_fit(config)
-print(fit.kC, fit.surface_tension)
+fixed_fit = spectrum.extract_kc_from_fit(fixed_config)
+print(fixed_fit.kC, fixed_fit.surface_tension)
 ```
 
 Calling `extract_kc_from_fit()` without a config is equivalent to the historical default fixed fit:
@@ -356,7 +356,7 @@ from vesmod.EdgeMod import (
     SpectrumFitConfig,
 )
 
-config = SpectrumFitConfig(
+dynamic_config = SpectrumFitConfig(
     range_selector=QMinusThreeFitRangeSelector(
         lower_bound=3,
         upper_bound=20,
@@ -366,12 +366,12 @@ config = SpectrumFitConfig(
     ),
 )
 
-dynamic_fit = spectrum.extract_kc_from_fit(config)
+dynamic_fit = spectrum.extract_kc_from_fit(dynamic_config)
 ```
 
 ### Compare fixed and dynamic fits
 
-Multiple successful fits are retained on the same `Spectrum`:
+The preceding snippets define `fixed_config` and `dynamic_config`, so both strategies can be run on the same `Spectrum`:
 
 ```python
 fixed_fit = spectrum.extract_kc_from_fit(fixed_config)
@@ -382,7 +382,7 @@ print(dynamic_fit.kC)
 print(spectrum.fit_results)
 ```
 
-`Spectrum.kC` and `Spectrum.surface_tension` remain compatibility attributes containing the most recent successful fit values. The durable per-fit record is `SpectrumFit`.
+`Spectrum.kC` and `Spectrum.surface_tension` are compatibility attributes containing the most recent successful physical fit values. A later range-selection rejection updates `Spectrum.fit_range_selection` but does not erase those successful values. The durable per-fit record is `SpectrumFit`.
 
 ---
 
@@ -406,12 +406,14 @@ edgemod sample.npy \
     --max-log-rmse 0.1
 ```
 
-After both commands, both files are available:
+After both successful commands, both files are available:
 
 ```text
 sample.json
 sample.dynamic.json
 ```
+
+If dynamic selection rejects the spectrum, `sample.dynamic.json` is still written with the rejection diagnostics before the CLI reports the error.
 
 ### Analyze every vesicle in one VesEdge QC result
 
@@ -469,7 +471,7 @@ When `--dynamic-range` is supplied, all of the following must also be supplied:
 
 ### `No trusted q range satisfied the q^-3 scaling criteria.`
 
-The spectrum did not contain a contiguous q range inside the trusted search interval that met both dynamic acceptance criteria. Possible responses include:
+The spectrum did not contain a contiguous q range inside the trusted search interval that met both dynamic acceptance criteria. The dynamic JSON output contains the selection diagnostics even though no physical fit was performed. Possible responses include:
 
 * inspect the spectrum for whether a q^-3 regime is present at all;
 * confirm that the trusted q interval is scientifically appropriate;

--- a/examples/EdgeMod_example_usage.py
+++ b/examples/EdgeMod_example_usage.py
@@ -5,23 +5,27 @@ Update runtime parameters and run this file, or adapt for your own use.
 """
 from pathlib import Path
 import glob
-from vesmod.EdgeMod import Spectrum
+from vesmod.EdgeMod import (
+    FixedFitRangeSelector,
+    Spectrum,
+    SpectrumFitConfig,
+)
 
 fpath = "YOUR/PATH/HERE/"  # path to the directory containing your .npy file(s)
-lower_fitting_bound = 3    # Lowest mode to fit to
-upper_fitting_bound = 8    # Ignore this mode and above when fitting
-lmax = 500                 # Maximum summation index
-free_sigma = True          # Fit surface tension (sigma) in addition to kc
+config = SpectrumFitConfig(
+    lmax=500,
+    free_sigma=True,
+    temperature=295.0,
+    range_selector=FixedFitRangeSelector(
+        lower_bound=3,
+        upper_bound=8,
+    ),
+)
 
 for file in glob.glob(fpath + '*.npy', recursive=True):
     path = Path(file).resolve()
     print(f"working on file {path.stem}")
     spectrum = Spectrum(file)
-    kc, sigma = spectrum.extract_kc_from_fit(
-        lower_bound=lower_fitting_bound,
-        upper_bound=upper_fitting_bound,
-        lmax=lmax,
-        free_sigma=free_sigma,
-    )
-    print(kc, sigma)
+    fit = spectrum.extract_kc_from_fit(config)
+    print(fit.kC, fit.surface_tension)
     spectrum.to_json(path)

--- a/tests/unit_tests/test_edgemod_cli.py
+++ b/tests/unit_tests/test_edgemod_cli.py
@@ -2,11 +2,13 @@
 
 from argparse import Namespace
 from pathlib import Path
+import json
 
+import numpy as np
 import pytest
 
 from vesmod.EdgeMod import FixedFitRangeSelector, QMinusThreeFitRangeSelector
-from vesmod.cli.edgemod_cli import build_fit_config, output_path_for
+from vesmod.cli.edgemod_cli import build_fit_config, output_path_for, process_file
 
 
 def _args(**overrides):
@@ -78,3 +80,27 @@ def test_dynamic_output_path_does_not_overwrite_fixed_output():
 
     assert output_path_for(path, dynamic_range=False) == Path("sample.json")
     assert output_path_for(path, dynamic_range=True) == Path("sample.dynamic.json")
+
+
+def test_process_file_serializes_dynamic_rejection_diagnostics(tmp_path):
+    """Test rejected dynamic fits write diagnostics before raising."""
+    path = tmp_path / "sample.npy"
+    np.save(path, np.ones((3, 12), dtype=float))
+    args = _args(
+        dynamic_range=True,
+        upper_fitting_bound=12,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+
+    with pytest.raises(ValueError):
+        process_file(path, args)
+
+    output_path = tmp_path / "sample.dynamic.json"
+    assert output_path.is_file()
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["fit_range_selection"]["accepted"] is False
+    assert data["fit_range_selection"]["reason"] is not None
+    assert data["kC"] is None
+    assert data["surface_tension"] is None

--- a/tests/unit_tests/test_edgemod_cli.py
+++ b/tests/unit_tests/test_edgemod_cli.py
@@ -1,0 +1,80 @@
+"""Tests for EdgeMod command-line fit configuration."""
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from vesmod.EdgeMod import FixedFitRangeSelector, QMinusThreeFitRangeSelector
+from vesmod.cli.edgemod_cli import build_fit_config, output_path_for
+
+
+def _args(**overrides):
+    """Return standard parsed CLI arguments with optional overrides."""
+    values = {
+        "dynamic_range": False,
+        "lower_fitting_bound": 3,
+        "upper_fitting_bound": 8,
+        "min_modes": None,
+        "slope_tolerance": None,
+        "max_log_rmse": None,
+        "lmax": 500,
+        "fixed_sigma": False,
+        "temperature": 295.0,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_build_fit_config_uses_fixed_selector_by_default():
+    """Test the CLI preserves the historical fixed-range behavior."""
+    config = build_fit_config(_args())
+
+    assert isinstance(config.range_selector, FixedFitRangeSelector)
+    assert config.range_selector.lower_bound == 3
+    assert config.range_selector.upper_bound == 8
+    assert config.lmax == 500
+    assert config.free_sigma is True
+    assert config.temperature == 295.0
+
+
+def test_build_fit_config_constructs_dynamic_selector():
+    """Test all dynamic-selection arguments are propagated into the config."""
+    config = build_fit_config(
+        _args(
+            dynamic_range=True,
+            upper_fitting_bound=15,
+            min_modes=5,
+            slope_tolerance=0.2,
+            max_log_rmse=0.1,
+            fixed_sigma=True,
+        )
+    )
+
+    assert isinstance(config.range_selector, QMinusThreeFitRangeSelector)
+    assert config.range_selector.lower_bound == 3
+    assert config.range_selector.upper_bound == 15
+    assert config.range_selector.min_modes == 5
+    assert config.range_selector.slope_tolerance == 0.2
+    assert config.range_selector.max_log_rmse == 0.1
+    assert config.free_sigma is False
+
+
+def test_build_fit_config_requires_explicit_dynamic_thresholds():
+    """Test dynamic fitting cannot silently use empirical acceptance defaults."""
+    with pytest.raises(ValueError, match="--slope-tolerance"):
+        build_fit_config(
+            _args(
+                dynamic_range=True,
+                min_modes=5,
+                max_log_rmse=0.1,
+            )
+        )
+
+
+def test_dynamic_output_path_does_not_overwrite_fixed_output():
+    """Test fixed and dynamic CLI runs use distinct JSON filenames."""
+    path = Path("sample.npy")
+
+    assert output_path_for(path, dynamic_range=False) == Path("sample.json")
+    assert output_path_for(path, dynamic_range=True) == Path("sample.dynamic.json")

--- a/tests/unit_tests/test_fit_range_selection.py
+++ b/tests/unit_tests/test_fit_range_selection.py
@@ -1,0 +1,159 @@
+"""Unit tests for EdgeMod spectrum fit-range selection."""
+
+import numpy as np
+import pytest
+
+from vesmod.EdgeMod import (
+    FixedFitRangeSelector,
+    QMinusThreeFitRangeSelector,
+)
+
+
+def test_fixed_selector_returns_configured_range():
+    """Test fixed selection preserves lower-inclusive, upper-exclusive bounds."""
+    selector = FixedFitRangeSelector(3, 8)
+    modes = np.arange(0, 10)
+    amplitudes = np.ones(10)
+
+    result = selector.select(modes, amplitudes)
+
+    assert result.accepted
+    assert result.lower_bound == 3
+    assert result.upper_bound == 8
+
+
+def test_q_minus_three_selector_prefers_longest_acceptable_range():
+    """Test an exact q^-3 spectrum selects the full trusted range."""
+    modes = np.arange(3, 11)
+    amplitudes = 2.0 * modes.astype(float) ** -3
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=11,
+        min_modes=5,
+    )
+
+    result = selector.select(modes, amplitudes)
+
+    assert result.accepted
+    assert result.lower_bound == 3
+    assert result.upper_bound == 11
+    assert result.slope == pytest.approx(-3.0)
+    assert result.log_rmse == pytest.approx(0.0, abs=1e-12)
+
+
+def test_q_minus_three_selector_can_exclude_bad_low_q_modes():
+    """Test the selector finds a later contiguous q^-3 scaling regime."""
+    modes = np.arange(3, 12)
+    amplitudes = modes.astype(float) ** -3
+    amplitudes[:2] *= np.array([8.0, 0.2])
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=12,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+
+    result = selector.select(modes, amplitudes)
+
+    assert result.accepted
+    assert result.lower_bound == 5
+    assert result.upper_bound == 12
+
+
+def test_q_minus_three_selector_rejects_spectrum_without_scaling():
+    """Test a q^-2 spectrum is rejected instead of being physically fit."""
+    modes = np.arange(3, 11)
+    amplitudes = modes.astype(float) ** -2
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=11,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+
+    result = selector.select(modes, amplitudes)
+
+    assert not result.accepted
+    assert result.reason == "No trusted q range satisfied the q^-3 scaling criteria."
+    assert result.slope is not None
+    assert result.log_rmse is not None
+
+
+def test_q_minus_three_selector_ignores_scaling_outside_trusted_range():
+    """Test q^-3 behavior above the allowed q range cannot rescue a spectrum."""
+    modes = np.arange(3, 15)
+    amplitudes = modes.astype(float) ** -2
+    high_q = modes >= 9
+    amplitudes[high_q] = modes[high_q].astype(float) ** -3
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=9,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+
+    result = selector.select(modes, amplitudes)
+
+    assert not result.accepted
+
+
+def test_q_minus_three_selector_rejects_too_short_scaling_region():
+    """Test a short accidental q^-3 match does not satisfy min_modes."""
+    modes = np.arange(3, 11)
+    amplitudes = modes.astype(float) ** -2
+    short_range = (modes >= 5) & (modes <= 7)
+    amplitudes[short_range] = 10.0 * modes[short_range].astype(float) ** -3
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=11,
+        min_modes=5,
+        slope_tolerance=0.01,
+        max_log_rmse=0.01,
+    )
+
+    result = selector.select(modes, amplitudes)
+
+    assert not result.accepted
+
+
+def test_q_minus_three_selector_rejects_insufficient_usable_modes():
+    """Test non-positive amplitudes do not count as log-space fit modes."""
+    modes = np.arange(3, 8)
+    amplitudes = np.array([1.0, 0.0, np.nan, 0.1, 0.05])
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=8,
+        min_modes=4,
+    )
+
+    result = selector.select(modes, amplitudes)
+
+    assert not result.accepted
+    assert result.lower_bound is None
+    assert result.upper_bound is None
+    assert "fewer than 4 usable modes" in result.reason
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"lower_bound": 0, "upper_bound": 8}, "lower_bound"),
+        ({"lower_bound": 8, "upper_bound": 8}, "upper_bound"),
+        ({"lower_bound": 3, "upper_bound": 8, "min_modes": 1}, "min_modes"),
+        (
+            {"lower_bound": 3, "upper_bound": 8, "slope_tolerance": -0.1},
+            "slope_tolerance",
+        ),
+        (
+            {"lower_bound": 3, "upper_bound": 8, "max_log_rmse": -0.1},
+            "max_log_rmse",
+        ),
+    ],
+)
+def test_q_minus_three_selector_validates_configuration(kwargs, message):
+    """Test invalid dynamic-selection settings fail clearly."""
+    with pytest.raises(ValueError, match=message):
+        QMinusThreeFitRangeSelector(**kwargs)

--- a/tests/unit_tests/test_fit_range_selection.py
+++ b/tests/unit_tests/test_fit_range_selection.py
@@ -9,6 +9,19 @@ from vesmod.EdgeMod import (
 )
 
 
+def _selector(**overrides):
+    """Return a selector with explicit baseline acceptance criteria."""
+    kwargs = {
+        "lower_bound": 3,
+        "upper_bound": 11,
+        "min_modes": 5,
+        "slope_tolerance": 0.1,
+        "max_log_rmse": 0.05,
+    }
+    kwargs.update(overrides)
+    return QMinusThreeFitRangeSelector(**kwargs)
+
+
 def test_fixed_selector_returns_configured_range():
     """Test fixed selection preserves lower-inclusive, upper-exclusive bounds."""
     selector = FixedFitRangeSelector(3, 8)
@@ -26,11 +39,7 @@ def test_q_minus_three_selector_prefers_longest_acceptable_range():
     """Test an exact q^-3 spectrum selects the full trusted range."""
     modes = np.arange(3, 11)
     amplitudes = 2.0 * modes.astype(float) ** -3
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=11,
-        min_modes=5,
-    )
+    selector = _selector()
 
     result = selector.select(modes, amplitudes)
 
@@ -46,13 +55,7 @@ def test_q_minus_three_selector_can_exclude_bad_low_q_modes():
     modes = np.arange(3, 12)
     amplitudes = modes.astype(float) ** -3
     amplitudes[:2] *= np.array([8.0, 0.2])
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=12,
-        min_modes=5,
-        slope_tolerance=0.1,
-        max_log_rmse=0.05,
-    )
+    selector = _selector(upper_bound=12)
 
     result = selector.select(modes, amplitudes)
 
@@ -65,13 +68,7 @@ def test_q_minus_three_selector_rejects_spectrum_without_scaling():
     """Test a q^-2 spectrum is rejected instead of being physically fit."""
     modes = np.arange(3, 11)
     amplitudes = modes.astype(float) ** -2
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=11,
-        min_modes=5,
-        slope_tolerance=0.1,
-        max_log_rmse=0.05,
-    )
+    selector = _selector()
 
     result = selector.select(modes, amplitudes)
 
@@ -87,13 +84,7 @@ def test_q_minus_three_selector_ignores_scaling_outside_trusted_range():
     amplitudes = modes.astype(float) ** -2
     high_q = modes >= 9
     amplitudes[high_q] = modes[high_q].astype(float) ** -3
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=9,
-        min_modes=5,
-        slope_tolerance=0.1,
-        max_log_rmse=0.05,
-    )
+    selector = _selector(upper_bound=9)
 
     result = selector.select(modes, amplitudes)
 
@@ -106,10 +97,7 @@ def test_q_minus_three_selector_rejects_too_short_scaling_region():
     amplitudes = modes.astype(float) ** -2
     short_range = (modes >= 5) & (modes <= 7)
     amplitudes[short_range] = 10.0 * modes[short_range].astype(float) ** -3
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=11,
-        min_modes=5,
+    selector = _selector(
         slope_tolerance=0.01,
         max_log_rmse=0.01,
     )
@@ -123,11 +111,7 @@ def test_q_minus_three_selector_rejects_insufficient_usable_modes():
     """Test non-positive amplitudes do not count as log-space fit modes."""
     modes = np.arange(3, 8)
     amplitudes = np.array([1.0, 0.0, np.nan, 0.1, 0.05])
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=8,
-        min_modes=4,
-    )
+    selector = _selector(upper_bound=8, min_modes=4)
 
     result = selector.select(modes, amplitudes)
 
@@ -138,22 +122,32 @@ def test_q_minus_three_selector_rejects_insufficient_usable_modes():
 
 
 @pytest.mark.parametrize(
-    "kwargs, message",
+    "overrides, message",
     [
-        ({"lower_bound": 0, "upper_bound": 8}, "lower_bound"),
-        ({"lower_bound": 8, "upper_bound": 8}, "upper_bound"),
-        ({"lower_bound": 3, "upper_bound": 8, "min_modes": 1}, "min_modes"),
-        (
-            {"lower_bound": 3, "upper_bound": 8, "slope_tolerance": -0.1},
-            "slope_tolerance",
-        ),
-        (
-            {"lower_bound": 3, "upper_bound": 8, "max_log_rmse": -0.1},
-            "max_log_rmse",
-        ),
+        ({"lower_bound": 0}, "lower_bound"),
+        ({"upper_bound": 3}, "upper_bound"),
+        ({"min_modes": 1}, "min_modes"),
+        ({"slope_tolerance": -0.1}, "slope_tolerance"),
+        ({"max_log_rmse": -0.1}, "max_log_rmse"),
     ],
 )
-def test_q_minus_three_selector_validates_configuration(kwargs, message):
-    """Test invalid dynamic-selection settings fail clearly."""
+def test_q_minus_three_selector_validates_configuration(overrides, message):
+    """Test invalid dynamic-selection values fail clearly."""
     with pytest.raises(ValueError, match=message):
-        QMinusThreeFitRangeSelector(**kwargs)
+        _selector(**overrides)
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"lower_bound": 3.5}, "lower_bound"),
+        ({"upper_bound": 11.5}, "upper_bound"),
+        ({"min_modes": 5.5}, "min_modes"),
+        ({"slope_tolerance": "0.1"}, "slope_tolerance"),
+        ({"max_log_rmse": "0.05"}, "max_log_rmse"),
+    ],
+)
+def test_q_minus_three_selector_validates_configuration_types(overrides, message):
+    """Test dynamic-selection configuration types are explicit."""
+    with pytest.raises(TypeError, match=message):
+        _selector(**overrides)

--- a/tests/unit_tests/test_fit_range_selection.py
+++ b/tests/unit_tests/test_fit_range_selection.py
@@ -140,6 +140,21 @@ def test_q_minus_three_selector_validates_configuration(overrides, message):
 @pytest.mark.parametrize(
     "overrides, message",
     [
+        ({"slope_tolerance": np.nan}, "slope_tolerance must be finite"),
+        ({"slope_tolerance": np.inf}, "slope_tolerance must be finite"),
+        ({"max_log_rmse": np.nan}, "max_log_rmse must be finite"),
+        ({"max_log_rmse": np.inf}, "max_log_rmse must be finite"),
+    ],
+)
+def test_q_minus_three_selector_rejects_nonfinite_thresholds(overrides, message):
+    """Test dynamic acceptance thresholds must be finite."""
+    with pytest.raises(ValueError, match=message):
+        _selector(**overrides)
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
         ({"lower_bound": 3.5}, "lower_bound"),
         ({"upper_bound": 11.5}, "upper_bound"),
         ({"min_modes": 5.5}, "min_modes"),

--- a/tests/unit_tests/test_spectrum.py
+++ b/tests/unit_tests/test_spectrum.py
@@ -6,7 +6,11 @@ import json
 import numpy as np
 import pytest
 
-from vesmod.EdgeMod import Spectrum
+from vesmod.EdgeMod import (
+    FixedFitRangeSelector,
+    Spectrum,
+    SpectrumFitConfig,
+)
 from vesmod.EdgeMod.spectrum_utils import MiniSpectrum
 from vesmod.VesEdge import (
     EdgeDetection,
@@ -234,14 +238,16 @@ def test_isolate_mode_range_raises_when_modes_are_missing():
         spectrum.isolate_mode_range(1, 3)
 
 
-def test_extract_kc_from_fit_uses_mode_range_and_saves_fit_results(monkeypatch):
-    """Test fitting uses the requested modes and stores converted results."""
+def test_extract_kc_from_fit_uses_config_and_saves_fit_results(monkeypatch):
+    """Test fitting uses the configured modes and physical-fit settings."""
     spectrum = Spectrum.__new__(Spectrum)
     spectrum.r0 = 10.0
     spectrum.modes = np.array([0, 1, 2, 3, 4, 5])
     spectrum.avg_amps2 = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
     spectrum.kC = None
     spectrum.surface_tension = None
+    spectrum.fit_range_selection = None
+    spectrum.fit_results = []
     calls = {}
 
     def fake_fit_spectrum_to_theory_lmfit(fitting_range, lmax, free_sigma):
@@ -273,14 +279,14 @@ def test_extract_kc_from_fit_uses_mode_range_and_saves_fit_results(monkeypatch):
         "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",
         fake_calc_tension_from_reduced_tension,
     )
-
-    kc, surface_tension = spectrum.extract_kc_from_fit(
-        lower_bound=2,
-        upper_bound=5,
+    config = SpectrumFitConfig(
         lmax=123,
         free_sigma=True,
         temperature=310.0,
+        range_selector=FixedFitRangeSelector(2, 5),
     )
+
+    kc, surface_tension = spectrum.extract_kc_from_fit(config)
 
     np.testing.assert_array_equal(calls["modes"], np.array([2, 3, 4]))
     np.testing.assert_array_equal(
@@ -294,6 +300,42 @@ def test_extract_kc_from_fit_uses_mode_range_and_saves_fit_results(monkeypatch):
     assert surface_tension == 9.9
     assert spectrum.kC == 22.0
     assert spectrum.surface_tension == 9.9
+    assert spectrum.fit_results[0].config is config
+
+
+def test_extract_kc_from_fit_uses_default_config(monkeypatch):
+    """Test omitted config preserves the historical fixed q=3--7 fit."""
+    spectrum = Spectrum.__new__(Spectrum)
+    spectrum.r0 = 10.0
+    spectrum.modes = np.arange(0, 9)
+    spectrum.avg_amps2 = np.ones(9)
+    spectrum.kC = None
+    spectrum.surface_tension = None
+    spectrum.fit_range_selection = None
+    spectrum.fit_results = []
+    calls = {}
+
+    def fake_fit(fitting_range, lmax, free_sigma):
+        calls["modes"] = fitting_range.modes.copy()
+        calls["lmax"] = lmax
+        calls["free_sigma"] = free_sigma
+        return 20.0, 2.0
+
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        fake_fit,
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",
+        lambda *args: 1.0,
+    )
+
+    fit = spectrum.extract_kc_from_fit()
+
+    np.testing.assert_array_equal(calls["modes"], np.arange(3, 8))
+    assert calls["lmax"] == 500
+    assert calls["free_sigma"] is True
+    assert isinstance(fit.config.range_selector, FixedFitRangeSelector)
 
 
 def test_to_dict_includes_arrays_when_requested():

--- a/tests/unit_tests/test_spectrum_dynamic_fit.py
+++ b/tests/unit_tests/test_spectrum_dynamic_fit.py
@@ -3,7 +3,11 @@
 import numpy as np
 import pytest
 
-from vesmod.EdgeMod import QMinusThreeFitRangeSelector, Spectrum
+from vesmod.EdgeMod import (
+    QMinusThreeFitRangeSelector,
+    Spectrum,
+    SpectrumFitConfig,
+)
 
 
 def _spectrum_with_power_law() -> Spectrum:
@@ -19,19 +23,29 @@ def _spectrum_with_power_law() -> Spectrum:
     spectrum.kC = None
     spectrum.surface_tension = None
     spectrum.fit_range_selection = None
+    spectrum.fit_results = []
     return spectrum
+
+
+def _dynamic_config() -> SpectrumFitConfig:
+    """Return standard dynamic-selection settings for these tests."""
+    return SpectrumFitConfig(
+        lmax=400,
+        free_sigma=False,
+        range_selector=QMinusThreeFitRangeSelector(
+            lower_bound=3,
+            upper_bound=12,
+            min_modes=5,
+            slope_tolerance=0.1,
+            max_log_rmse=0.05,
+        ),
+    )
 
 
 def test_extract_kc_from_fit_uses_dynamic_selected_range(monkeypatch):
     """Test the physical fitter receives only the dynamically selected modes."""
     spectrum = _spectrum_with_power_law()
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=12,
-        min_modes=5,
-        slope_tolerance=0.1,
-        max_log_rmse=0.05,
-    )
+    config = _dynamic_config()
     calls = {}
 
     def fake_fit(fitting_range, lmax, free_sigma):
@@ -49,11 +63,7 @@ def test_extract_kc_from_fit_uses_dynamic_selected_range(monkeypatch):
         lambda *args: 1.5,
     )
 
-    kc, tension = spectrum.extract_kc_from_fit(
-        lmax=400,
-        free_sigma=False,
-        range_selector=selector,
-    )
+    fit = spectrum.extract_kc_from_fit(config)
 
     np.testing.assert_array_equal(calls["modes"], np.arange(5, 12))
     assert calls["lmax"] == 400
@@ -62,8 +72,9 @@ def test_extract_kc_from_fit_uses_dynamic_selected_range(monkeypatch):
     assert spectrum.fit_range_selection.accepted
     assert spectrum.fit_range_selection.lower_bound == 5
     assert spectrum.fit_range_selection.upper_bound == 12
-    assert kc == 20.0
-    assert tension == 1.5
+    assert fit.kC == 20.0
+    assert fit.surface_tension == 1.5
+    assert fit.config is config
 
 
 def test_extract_kc_from_fit_rejects_before_physical_fit(monkeypatch):
@@ -77,13 +88,8 @@ def test_extract_kc_from_fit_rejects_before_physical_fit(monkeypatch):
     spectrum.kC = 99.0
     spectrum.surface_tension = 99.0
     spectrum.fit_range_selection = None
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=12,
-        min_modes=5,
-        slope_tolerance=0.1,
-        max_log_rmse=0.05,
-    )
+    spectrum.fit_results = []
+    config = _dynamic_config()
 
     def fail_if_called(*args, **kwargs):
         pytest.fail("Physical spectrum fitter should not run after range rejection.")
@@ -94,24 +100,19 @@ def test_extract_kc_from_fit_rejects_before_physical_fit(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="No trusted q range"):
-        spectrum.extract_kc_from_fit(range_selector=selector)
+        spectrum.extract_kc_from_fit(config)
 
     assert spectrum.fit_range_selection is not None
     assert not spectrum.fit_range_selection.accepted
     assert spectrum.kC is None
     assert spectrum.surface_tension is None
+    assert spectrum.fit_results == []
 
 
 def test_to_dict_serializes_dynamic_range_diagnostics():
     """Test dynamic selection diagnostics are available to later reporting."""
     spectrum = _spectrum_with_power_law()
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=12,
-        min_modes=5,
-        slope_tolerance=0.1,
-        max_log_rmse=0.05,
-    )
+    selector = _dynamic_config().range_selector
     spectrum.fit_range_selection = selector.select(
         spectrum.modes,
         spectrum.avg_amps2,

--- a/tests/unit_tests/test_spectrum_dynamic_fit.py
+++ b/tests/unit_tests/test_spectrum_dynamic_fit.py
@@ -1,0 +1,129 @@
+"""Integration tests for dynamic EdgeMod spectrum fit-range selection."""
+
+import numpy as np
+import pytest
+
+from vesmod.EdgeMod import QMinusThreeFitRangeSelector, Spectrum
+
+
+def _spectrum_with_power_law() -> Spectrum:
+    """Return a minimal Spectrum carrying q^-3 amplitudes from q=5 onward."""
+    spectrum = Spectrum.__new__(Spectrum)
+    spectrum.r0 = 10.0
+    spectrum.modes = np.arange(0, 12)
+    spectrum.avg_amps2 = np.ones(12, dtype=float)
+    q = spectrum.modes[3:].astype(float)
+    spectrum.avg_amps2[3:] = q ** -3
+    spectrum.avg_amps2[3] *= 8.0
+    spectrum.avg_amps2[4] *= 0.2
+    spectrum.kC = None
+    spectrum.surface_tension = None
+    spectrum.fit_range_selection = None
+    return spectrum
+
+
+def test_extract_kc_from_fit_uses_dynamic_selected_range(monkeypatch):
+    """Test the physical fitter receives only the dynamically selected modes."""
+    spectrum = _spectrum_with_power_law()
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=12,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+    calls = {}
+
+    def fake_fit(fitting_range, lmax, free_sigma):
+        calls["modes"] = fitting_range.modes.copy()
+        calls["lmax"] = lmax
+        calls["free_sigma"] = free_sigma
+        return 20.0, 2.0
+
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        fake_fit,
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",
+        lambda *args: 1.5,
+    )
+
+    kc, tension = spectrum.extract_kc_from_fit(
+        lmax=400,
+        free_sigma=False,
+        range_selector=selector,
+    )
+
+    np.testing.assert_array_equal(calls["modes"], np.arange(5, 12))
+    assert calls["lmax"] == 400
+    assert calls["free_sigma"] is False
+    assert spectrum.fit_range_selection is not None
+    assert spectrum.fit_range_selection.accepted
+    assert spectrum.fit_range_selection.lower_bound == 5
+    assert spectrum.fit_range_selection.upper_bound == 12
+    assert kc == 20.0
+    assert tension == 1.5
+
+
+def test_extract_kc_from_fit_rejects_before_physical_fit(monkeypatch):
+    """Test a spectrum without q^-3 scaling never reaches the HSS97 fitter."""
+    spectrum = Spectrum.__new__(Spectrum)
+    spectrum.r0 = 10.0
+    spectrum.modes = np.arange(0, 12)
+    spectrum.avg_amps2 = np.ones(12, dtype=float)
+    q = spectrum.modes[3:].astype(float)
+    spectrum.avg_amps2[3:] = q ** -2
+    spectrum.kC = 99.0
+    spectrum.surface_tension = 99.0
+    spectrum.fit_range_selection = None
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=12,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+
+    def fail_if_called(*args, **kwargs):
+        pytest.fail("Physical spectrum fitter should not run after range rejection.")
+
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        fail_if_called,
+    )
+
+    with pytest.raises(ValueError, match="No trusted q range"):
+        spectrum.extract_kc_from_fit(range_selector=selector)
+
+    assert spectrum.fit_range_selection is not None
+    assert not spectrum.fit_range_selection.accepted
+    assert spectrum.kC is None
+    assert spectrum.surface_tension is None
+
+
+def test_to_dict_serializes_dynamic_range_diagnostics():
+    """Test dynamic selection diagnostics are available to later reporting."""
+    spectrum = _spectrum_with_power_law()
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=12,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+    spectrum.fit_range_selection = selector.select(
+        spectrum.modes,
+        spectrum.avg_amps2,
+    )
+
+    data = spectrum._to_dict(include_arrays=False)
+
+    assert data["fit_range_selection"]["accepted"] is True
+    assert data["fit_range_selection"]["lower_bound"] == 5
+    assert data["fit_range_selection"]["upper_bound"] == 12
+    assert data["fit_range_selection"]["slope"] == pytest.approx(-3.0)
+    assert data["fit_range_selection"]["log_rmse"] == pytest.approx(
+        0.0,
+        abs=1e-12,
+    )

--- a/tests/unit_tests/test_spectrum_dynamic_fit.py
+++ b/tests/unit_tests/test_spectrum_dynamic_fit.py
@@ -78,7 +78,7 @@ def test_extract_kc_from_fit_uses_dynamic_selected_range(monkeypatch):
 
 
 def test_extract_kc_from_fit_rejects_before_physical_fit(monkeypatch):
-    """Test a spectrum without q^-3 scaling never reaches the HSS97 fitter."""
+    """Test rejection preserves the most recent successful fit values."""
     spectrum = Spectrum.__new__(Spectrum)
     spectrum.r0 = 10.0
     spectrum.modes = np.arange(0, 12)
@@ -86,7 +86,7 @@ def test_extract_kc_from_fit_rejects_before_physical_fit(monkeypatch):
     q = spectrum.modes[3:].astype(float)
     spectrum.avg_amps2[3:] = q ** -2
     spectrum.kC = 99.0
-    spectrum.surface_tension = 99.0
+    spectrum.surface_tension = 98.0
     spectrum.fit_range_selection = None
     spectrum.fit_results = []
     config = _dynamic_config()
@@ -104,8 +104,8 @@ def test_extract_kc_from_fit_rejects_before_physical_fit(monkeypatch):
 
     assert spectrum.fit_range_selection is not None
     assert not spectrum.fit_range_selection.accepted
-    assert spectrum.kC is None
-    assert spectrum.surface_tension is None
+    assert spectrum.kC == 99.0
+    assert spectrum.surface_tension == 98.0
     assert spectrum.fit_results == []
 
 

--- a/tests/unit_tests/test_spectrum_fit_config.py
+++ b/tests/unit_tests/test_spectrum_fit_config.py
@@ -1,5 +1,6 @@
 """Tests for EdgeMod SpectrumFitConfig."""
 
+import numpy as np
 import pytest
 
 from vesmod.EdgeMod import (
@@ -62,4 +63,11 @@ def test_config_rejects_nonpositive_lmax(lmax):
 def test_config_rejects_nonpositive_temperature(temperature):
     """Test temperature must be physically positive."""
     with pytest.raises(ValueError, match="temperature must be positive"):
+        SpectrumFitConfig(temperature=temperature)
+
+
+@pytest.mark.parametrize("temperature", [np.nan, np.inf, -np.inf])
+def test_config_rejects_nonfinite_temperature(temperature):
+    """Test temperature must be finite before fitting or serialization."""
+    with pytest.raises(ValueError, match="temperature must be finite"):
         SpectrumFitConfig(temperature=temperature)

--- a/tests/unit_tests/test_spectrum_fit_config.py
+++ b/tests/unit_tests/test_spectrum_fit_config.py
@@ -1,0 +1,65 @@
+"""Tests for EdgeMod SpectrumFitConfig."""
+
+import pytest
+
+from vesmod.EdgeMod import (
+    FixedFitRangeSelector,
+    QMinusThreeFitRangeSelector,
+    SpectrumFitConfig,
+)
+
+
+def test_default_config_preserves_historical_fit_settings():
+    """Test defaults reproduce the existing fixed q=3--7 fit."""
+    config = SpectrumFitConfig()
+
+    assert config.lmax == 500
+    assert config.free_sigma is True
+    assert config.temperature == 295.0
+    assert isinstance(config.range_selector, FixedFitRangeSelector)
+    assert config.range_selector.lower_bound == 3
+    assert config.range_selector.upper_bound == 8
+
+
+def test_config_serializes_dynamic_selector_parameters():
+    """Test scientific fit settings are retained for reproducibility."""
+    config = SpectrumFitConfig(
+        lmax=400,
+        free_sigma=False,
+        temperature=310.0,
+        range_selector=QMinusThreeFitRangeSelector(
+            lower_bound=3,
+            upper_bound=15,
+            min_modes=5,
+            slope_tolerance=0.2,
+            max_log_rmse=0.1,
+        ),
+    )
+
+    data = config.to_dict()
+
+    assert data["lmax"] == 400
+    assert data["free_sigma"] is False
+    assert data["temperature"] == 310.0
+    assert data["range_selector"] == {
+        "type": "QMinusThreeFitRangeSelector",
+        "lower_bound": 3,
+        "upper_bound": 15,
+        "min_modes": 5,
+        "slope_tolerance": 0.2,
+        "max_log_rmse": 0.1,
+    }
+
+
+@pytest.mark.parametrize("lmax", [0, -1])
+def test_config_rejects_nonpositive_lmax(lmax):
+    """Test lmax must be positive."""
+    with pytest.raises(ValueError, match="lmax must be positive"):
+        SpectrumFitConfig(lmax=lmax)
+
+
+@pytest.mark.parametrize("temperature", [0.0, -1.0])
+def test_config_rejects_nonpositive_temperature(temperature):
+    """Test temperature must be physically positive."""
+    with pytest.raises(ValueError, match="temperature must be positive"):
+        SpectrumFitConfig(temperature=temperature)

--- a/tests/unit_tests/test_spectrum_fit_results.py
+++ b/tests/unit_tests/test_spectrum_fit_results.py
@@ -2,7 +2,13 @@
 
 import numpy as np
 
-from vesmod.EdgeMod import QMinusThreeFitRangeSelector, Spectrum, SpectrumFit
+from vesmod.EdgeMod import (
+    FixedFitRangeSelector,
+    QMinusThreeFitRangeSelector,
+    Spectrum,
+    SpectrumFit,
+    SpectrumFitConfig,
+)
 
 
 def _spectrum() -> Spectrum:
@@ -25,12 +31,17 @@ def _spectrum() -> Spectrum:
 def test_fixed_and_dynamic_fits_are_both_preserved(monkeypatch):
     """Test a later fit does not replace an earlier fit result."""
     spectrum = _spectrum()
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=12,
-        min_modes=5,
-        slope_tolerance=0.1,
-        max_log_rmse=0.05,
+    fixed_config = SpectrumFitConfig(
+        range_selector=FixedFitRangeSelector(3, 8),
+    )
+    dynamic_config = SpectrumFitConfig(
+        range_selector=QMinusThreeFitRangeSelector(
+            lower_bound=3,
+            upper_bound=12,
+            min_modes=5,
+            slope_tolerance=0.1,
+            max_log_rmse=0.05,
+        )
     )
 
     def fake_fit(fitting_range, lmax, free_sigma):
@@ -45,12 +56,12 @@ def test_fixed_and_dynamic_fits_are_both_preserved(monkeypatch):
         lambda r0, reduced_sigma, kc, temperature: kc / 10.0,
     )
 
-    fixed = spectrum.extract_kc_from_fit(lower_bound=3, upper_bound=8)
-    dynamic = spectrum.extract_kc_from_fit(range_selector=selector)
+    fixed = spectrum.extract_kc_from_fit(fixed_config)
+    dynamic = spectrum.extract_kc_from_fit(dynamic_config)
 
     assert isinstance(fixed, SpectrumFit)
     assert isinstance(dynamic, SpectrumFit)
-    assert fixed.method == "fixed"
+    assert fixed.method == "FixedFitRangeSelector"
     assert fixed.lower_bound == 3
     assert fixed.upper_bound == 8
     assert fixed.kC == 3.0
@@ -63,14 +74,15 @@ def test_fixed_and_dynamic_fits_are_both_preserved(monkeypatch):
     assert spectrum.surface_tension == dynamic.surface_tension
 
 
-def test_spectrum_fit_supports_legacy_tuple_unpacking():
-    """Test callers can still unpack a SpectrumFit as kc and tension."""
+def test_spectrum_fit_supports_tuple_unpacking():
+    """Test callers can unpack a SpectrumFit as kc and tension."""
+    config = SpectrumFitConfig()
     fit = SpectrumFit(
         kC=20.0,
         surface_tension=1.5,
         lower_bound=3,
         upper_bound=8,
-        method="fixed",
+        config=config,
     )
 
     kc, tension = fit
@@ -82,12 +94,17 @@ def test_spectrum_fit_supports_legacy_tuple_unpacking():
 def test_to_dict_serializes_all_fit_results(monkeypatch):
     """Test fixed and dynamic analyses coexist in one serialized Spectrum."""
     spectrum = _spectrum()
-    selector = QMinusThreeFitRangeSelector(
-        lower_bound=3,
-        upper_bound=12,
-        min_modes=5,
-        slope_tolerance=0.1,
-        max_log_rmse=0.05,
+    fixed_config = SpectrumFitConfig(
+        range_selector=FixedFitRangeSelector(3, 8),
+    )
+    dynamic_config = SpectrumFitConfig(
+        range_selector=QMinusThreeFitRangeSelector(
+            lower_bound=3,
+            upper_bound=12,
+            min_modes=5,
+            slope_tolerance=0.1,
+            max_log_rmse=0.05,
+        )
     )
 
     monkeypatch.setattr(
@@ -102,14 +119,19 @@ def test_to_dict_serializes_all_fit_results(monkeypatch):
         lambda r0, reduced_sigma, kc, temperature: kc / 10.0,
     )
 
-    spectrum.extract_kc_from_fit(lower_bound=3, upper_bound=8)
-    spectrum.extract_kc_from_fit(range_selector=selector)
+    spectrum.extract_kc_from_fit(fixed_config)
+    spectrum.extract_kc_from_fit(dynamic_config)
 
     data = spectrum._to_dict(include_arrays=False)
 
     assert len(data["fit_results"]) == 2
-    assert data["fit_results"][0]["method"] == "fixed"
+    assert data["fit_results"][0]["method"] == "FixedFitRangeSelector"
     assert data["fit_results"][0]["lower_bound"] == 3
+    assert data["fit_results"][0]["config"]["lmax"] == 500
     assert data["fit_results"][1]["method"] == "QMinusThreeFitRangeSelector"
     assert data["fit_results"][1]["lower_bound"] == 5
     assert data["fit_results"][1]["range_selection"]["accepted"] is True
+    assert (
+        data["fit_results"][1]["config"]["range_selector"]["min_modes"]
+        == 5
+    )

--- a/tests/unit_tests/test_spectrum_fit_results.py
+++ b/tests/unit_tests/test_spectrum_fit_results.py
@@ -1,0 +1,115 @@
+"""Tests for preserving multiple EdgeMod fit results on one Spectrum."""
+
+import numpy as np
+
+from vesmod.EdgeMod import QMinusThreeFitRangeSelector, Spectrum, SpectrumFit
+
+
+def _spectrum() -> Spectrum:
+    """Return a minimal spectrum with q^-3 scaling from q=5 onward."""
+    spectrum = Spectrum.__new__(Spectrum)
+    spectrum.r0 = 10.0
+    spectrum.modes = np.arange(0, 12)
+    spectrum.avg_amps2 = np.ones(12, dtype=float)
+    q = spectrum.modes[3:].astype(float)
+    spectrum.avg_amps2[3:] = q ** -3
+    spectrum.avg_amps2[3] *= 8.0
+    spectrum.avg_amps2[4] *= 0.2
+    spectrum.kC = None
+    spectrum.surface_tension = None
+    spectrum.fit_range_selection = None
+    spectrum.fit_results = []
+    return spectrum
+
+
+def test_fixed_and_dynamic_fits_are_both_preserved(monkeypatch):
+    """Test a later fit does not replace an earlier fit result."""
+    spectrum = _spectrum()
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=12,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+
+    def fake_fit(fitting_range, lmax, free_sigma):
+        return float(fitting_range.modes[0]), 2.0
+
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        fake_fit,
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",
+        lambda r0, reduced_sigma, kc, temperature: kc / 10.0,
+    )
+
+    fixed = spectrum.extract_kc_from_fit(lower_bound=3, upper_bound=8)
+    dynamic = spectrum.extract_kc_from_fit(range_selector=selector)
+
+    assert isinstance(fixed, SpectrumFit)
+    assert isinstance(dynamic, SpectrumFit)
+    assert fixed.method == "fixed"
+    assert fixed.lower_bound == 3
+    assert fixed.upper_bound == 8
+    assert fixed.kC == 3.0
+    assert dynamic.method == "QMinusThreeFitRangeSelector"
+    assert dynamic.lower_bound == 5
+    assert dynamic.upper_bound == 12
+    assert dynamic.kC == 5.0
+    assert spectrum.fit_results == [fixed, dynamic]
+    assert spectrum.kC == dynamic.kC
+    assert spectrum.surface_tension == dynamic.surface_tension
+
+
+def test_spectrum_fit_supports_legacy_tuple_unpacking():
+    """Test callers can still unpack a SpectrumFit as kc and tension."""
+    fit = SpectrumFit(
+        kC=20.0,
+        surface_tension=1.5,
+        lower_bound=3,
+        upper_bound=8,
+        method="fixed",
+    )
+
+    kc, tension = fit
+
+    assert kc == 20.0
+    assert tension == 1.5
+
+
+def test_to_dict_serializes_all_fit_results(monkeypatch):
+    """Test fixed and dynamic analyses coexist in one serialized Spectrum."""
+    spectrum = _spectrum()
+    selector = QMinusThreeFitRangeSelector(
+        lower_bound=3,
+        upper_bound=12,
+        min_modes=5,
+        slope_tolerance=0.1,
+        max_log_rmse=0.05,
+    )
+
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        lambda fitting_range, lmax, free_sigma: (
+            float(fitting_range.modes[0]),
+            2.0,
+        ),
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",
+        lambda r0, reduced_sigma, kc, temperature: kc / 10.0,
+    )
+
+    spectrum.extract_kc_from_fit(lower_bound=3, upper_bound=8)
+    spectrum.extract_kc_from_fit(range_selector=selector)
+
+    data = spectrum._to_dict(include_arrays=False)
+
+    assert len(data["fit_results"]) == 2
+    assert data["fit_results"][0]["method"] == "fixed"
+    assert data["fit_results"][0]["lower_bound"] == 3
+    assert data["fit_results"][1]["method"] == "QMinusThreeFitRangeSelector"
+    assert data["fit_results"][1]["lower_bound"] == 5
+    assert data["fit_results"][1]["range_selection"]["accepted"] is True

--- a/vesmod/EdgeMod/__init__.py
+++ b/vesmod/EdgeMod/__init__.py
@@ -1,5 +1,18 @@
 """Import the necessary files."""
+from .fit_range_selection import (
+    FitRangeSelection,
+    FitRangeSelector,
+    FixedFitRangeSelector,
+    QMinusThreeFitRangeSelector,
+)
 from .spectrum import Spectrum
 from .spectrum_ensemble import SpectrumEnsemble
 
-__all__ = ["Spectrum", "SpectrumEnsemble"]
+__all__ = [
+    "FitRangeSelection",
+    "FitRangeSelector",
+    "FixedFitRangeSelector",
+    "QMinusThreeFitRangeSelector",
+    "Spectrum",
+    "SpectrumEnsemble",
+]

--- a/vesmod/EdgeMod/__init__.py
+++ b/vesmod/EdgeMod/__init__.py
@@ -5,6 +5,7 @@ from .fit_range_selection import (
     FixedFitRangeSelector,
     QMinusThreeFitRangeSelector,
 )
+from .fit_result import SpectrumFit
 from .spectrum import Spectrum
 from .spectrum_ensemble import SpectrumEnsemble
 
@@ -13,6 +14,7 @@ __all__ = [
     "FitRangeSelector",
     "FixedFitRangeSelector",
     "QMinusThreeFitRangeSelector",
+    "SpectrumFit",
     "Spectrum",
     "SpectrumEnsemble",
 ]

--- a/vesmod/EdgeMod/__init__.py
+++ b/vesmod/EdgeMod/__init__.py
@@ -1,4 +1,5 @@
 """Import the necessary files."""
+from .config import SpectrumFitConfig
 from .fit_range_selection import (
     FitRangeSelection,
     FitRangeSelector,
@@ -10,6 +11,7 @@ from .spectrum import Spectrum
 from .spectrum_ensemble import SpectrumEnsemble
 
 __all__ = [
+    "SpectrumFitConfig",
     "FitRangeSelection",
     "FitRangeSelector",
     "FixedFitRangeSelector",

--- a/vesmod/EdgeMod/config.py
+++ b/vesmod/EdgeMod/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
 from numbers import Integral, Real
+import math
 
 from .fit_range_selection import (
     FitRangeSelector,
@@ -29,8 +30,8 @@ class SpectrumFitConfig:
     free_sigma : bool, default=True
         Whether reduced surface tension is fitted as a free parameter.
     temperature : float, default=295.0
-        Experimental temperature in Kelvin used when converting reduced
-        tension to surface tension.
+        Finite, positive experimental temperature in Kelvin used when
+        converting reduced tension to surface tension.
     range_selector : FitRangeSelector
         Strategy used to select the lower-inclusive, upper-exclusive q range.
         The default is ``FixedFitRangeSelector(3, 8)``, corresponding to
@@ -60,6 +61,8 @@ class SpectrumFitConfig:
             bool,
         ):
             raise TypeError("temperature must be numeric.")
+        if not math.isfinite(self.temperature):
+            raise ValueError("temperature must be finite.")
         if self.temperature <= 0:
             raise ValueError("temperature must be positive.")
         if not hasattr(self.range_selector, "select"):

--- a/vesmod/EdgeMod/config.py
+++ b/vesmod/EdgeMod/config.py
@@ -1,0 +1,75 @@
+"""Configuration records for EdgeMod spectrum fitting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from numbers import Integral, Real
+
+from .fit_range_selection import (
+    FitRangeSelector,
+    FixedFitRangeSelector,
+)
+
+
+@dataclass(frozen=True)
+class SpectrumFitConfig:
+    """Configure physical fitting of one vesicle fluctuation spectrum.
+
+    Parameters
+    ----------
+    lmax : int
+        Maximum summation index in the theoretical spectrum model.
+    free_sigma : bool
+        Whether reduced surface tension is fitted as a free parameter.
+    temperature : float
+        Experimental temperature in Kelvin.
+    range_selector : FitRangeSelector
+        Strategy used to select the lower-inclusive, upper-exclusive q range.
+    """
+
+    lmax: int = 500
+    free_sigma: bool = True
+    temperature: float = 295.0
+    range_selector: FitRangeSelector = field(
+        default_factory=lambda: FixedFitRangeSelector(
+            lower_bound=3,
+            upper_bound=8,
+        )
+    )
+
+    def __post_init__(self) -> None:
+        """Validate spectrum-fitting configuration."""
+        if not isinstance(self.lmax, Integral) or isinstance(self.lmax, bool):
+            raise TypeError("lmax must be an integer.")
+        if self.lmax <= 0:
+            raise ValueError("lmax must be positive.")
+        if not isinstance(self.free_sigma, bool):
+            raise TypeError("free_sigma must be a bool.")
+        if not isinstance(self.temperature, Real) or isinstance(
+            self.temperature,
+            bool,
+        ):
+            raise TypeError("temperature must be numeric.")
+        if self.temperature <= 0:
+            raise ValueError("temperature must be positive.")
+        if not hasattr(self.range_selector, "select"):
+            raise TypeError("range_selector must provide a select method.")
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable representation of the fit configuration."""
+        selector = self.range_selector
+        selector_data = {"type": type(selector).__name__}
+        selector_fields = getattr(selector, "__dataclass_fields__", None)
+        if selector_fields is not None:
+            for selector_field in fields(selector):
+                selector_data[selector_field.name] = getattr(
+                    selector,
+                    selector_field.name,
+                )
+
+        return {
+            "lmax": int(self.lmax),
+            "free_sigma": self.free_sigma,
+            "temperature": float(self.temperature),
+            "range_selector": selector_data,
+        }

--- a/vesmod/EdgeMod/config.py
+++ b/vesmod/EdgeMod/config.py
@@ -1,4 +1,4 @@
-"""Configuration records for EdgeMod spectrum fitting."""
+"""Scientific configuration records for EdgeMod spectrum fitting."""
 
 from __future__ import annotations
 
@@ -13,18 +13,28 @@ from .fit_range_selection import (
 
 @dataclass(frozen=True)
 class SpectrumFitConfig:
-    """Configure physical fitting of one vesicle fluctuation spectrum.
+    """Configure one physical fit of a vesicle fluctuation spectrum.
+
+    The config groups all scientific choices that determine the physical fit.
+    The q-range selector may either return fixed bounds or dynamically select a
+    trustworthy range from the measured spectrum. Keeping these choices in one
+    immutable record makes repeated fits reproducible and allows each
+    :class:`~vesmod.EdgeMod.fit_result.SpectrumFit` to retain the exact settings
+    that produced it.
 
     Parameters
     ----------
-    lmax : int
+    lmax : int, default=500
         Maximum summation index in the theoretical spectrum model.
-    free_sigma : bool
+    free_sigma : bool, default=True
         Whether reduced surface tension is fitted as a free parameter.
-    temperature : float
-        Experimental temperature in Kelvin.
+    temperature : float, default=295.0
+        Experimental temperature in Kelvin used when converting reduced
+        tension to surface tension.
     range_selector : FitRangeSelector
         Strategy used to select the lower-inclusive, upper-exclusive q range.
+        The default is ``FixedFitRangeSelector(3, 8)``, corresponding to
+        q = 3, 4, 5, 6, 7.
     """
 
     lmax: int = 500
@@ -38,7 +48,7 @@ class SpectrumFitConfig:
     )
 
     def __post_init__(self) -> None:
-        """Validate spectrum-fitting configuration."""
+        """Validate scientific fit parameters and selector compatibility."""
         if not isinstance(self.lmax, Integral) or isinstance(self.lmax, bool):
             raise TypeError("lmax must be an integer.")
         if self.lmax <= 0:
@@ -56,7 +66,7 @@ class SpectrumFitConfig:
             raise TypeError("range_selector must provide a select method.")
 
     def to_dict(self) -> dict:
-        """Return a JSON-serializable representation of the fit configuration."""
+        """Return the config and selector parameters in JSON-serializable form."""
         selector = self.range_selector
         selector_data = {"type": type(selector).__name__}
         selector_fields = getattr(selector, "__dataclass_fields__", None)

--- a/vesmod/EdgeMod/fit_range_selection.py
+++ b/vesmod/EdgeMod/fit_range_selection.py
@@ -48,7 +48,7 @@ class FitRangeSelection:
         }
 
 
-class FitRangeSelector(Protocol):
+class FitRangeSelector(Protocol):  # pylint: disable=too-few-public-methods
     """Protocol for strategies that select q ranges from a spectrum."""
 
     def select(
@@ -69,7 +69,7 @@ class FixedFitRangeSelector:
     def select(
         self,
         modes: np.ndarray,
-        avg_amps2: np.ndarray,
+        _avg_amps2: np.ndarray,
     ) -> FitRangeSelection:
         """Return the configured range after validating that it is populated."""
         mask = (modes >= self.lower_bound) & (modes < self.upper_bound)

--- a/vesmod/EdgeMod/fit_range_selection.py
+++ b/vesmod/EdgeMod/fit_range_selection.py
@@ -243,7 +243,7 @@ class QMinusThreeFitRangeSelector:
         modes: np.ndarray,
         avg_amps2: np.ndarray,
     ) -> Iterator[FitRangeSelection]:
-        """Yield candidate windows using constant-cost prefix-sum statistics."""
+        """Yield windows while avoiding repeated full-window calculations."""
         run_starts = np.concatenate(
             ([0], np.flatnonzero(np.diff(modes) != 1) + 1)
         )
@@ -251,64 +251,55 @@ class QMinusThreeFitRangeSelector:
         for run_start, run_stop in zip(run_starts, run_stops, strict=True):
             if run_stop - run_start < self.min_modes:
                 continue
-            run_modes = modes[run_start:run_stop]
-            run_amps = avg_amps2[run_start:run_stop]
-            yield from self._windows_from_contiguous_run(run_modes, run_amps)
+            yield from self._windows_from_contiguous_run(
+                modes[run_start:run_stop],
+                avg_amps2[run_start:run_stop],
+            )
 
     def _windows_from_contiguous_run(
         self,
         modes: np.ndarray,
         avg_amps2: np.ndarray,
     ) -> Iterator[FitRangeSelection]:
-        """Yield all sufficiently long windows from one contiguous q run."""
+        """Yield windows using stable constant-cost incremental statistics."""
         log_q = np.log(modes.astype(float))
         log_amp = np.log(avg_amps2)
-        fixed_residual_coordinate = log_amp + 3.0 * log_q
-        prefixes = tuple(
-            np.concatenate(([0.0], np.cumsum(values)))
-            for values in (
-                log_q,
-                log_amp,
-                log_q * log_q,
-                log_q * log_amp,
-                fixed_residual_coordinate,
-                fixed_residual_coordinate * fixed_residual_coordinate,
-            )
-        )
-        for start in range(modes.size):
-            for stop in range(start + self.min_modes, modes.size + 1):
-                yield self._evaluate_window_from_prefixes(
-                    modes,
-                    start,
-                    stop,
-                    prefixes,
-                )
+        fixed_coordinate = log_amp + 3.0 * log_q
 
-    @staticmethod
-    def _evaluate_window_from_prefixes(
-        modes: np.ndarray,
-        start: int,
-        stop: int,
-        prefixes: tuple[np.ndarray, ...],
-    ) -> FitRangeSelection:
-        """Evaluate one window in constant time from prefix sums."""
-        sum_x, sum_y, sum_x2, sum_xy, sum_z, sum_z2 = (
-            prefix[stop] - prefix[start]
-            for prefix in prefixes
-        )
-        count = stop - start
-        denominator = count * sum_x2 - sum_x * sum_x
-        slope = (count * sum_xy - sum_x * sum_y) / denominator
-        mean_z = sum_z / count
-        variance_z = max(sum_z2 / count - mean_z * mean_z, 0.0)
-        log_rmse = math.sqrt(variance_z)
-        return FitRangeSelection(
-            accepted=True,
-            lower_bound=int(modes[start]),
-            upper_bound=int(modes[stop - 1]) + 1,
-            slope=float(slope),
-            log_rmse=float(log_rmse),
-        )
+        for start in range(modes.size):
+            count = 0
+            mean_x = 0.0
+            mean_y = 0.0
+            mean_z = 0.0
+            sum_xx = 0.0
+            sum_xy = 0.0
+            sum_zz = 0.0
+            for stop in range(start, modes.size):
+                count += 1
+
+                delta_x = log_q[stop] - mean_x
+                mean_x += delta_x / count
+                delta_y = log_amp[stop] - mean_y
+                mean_y += delta_y / count
+                sum_xx += delta_x * (log_q[stop] - mean_x)
+                sum_xy += delta_x * (log_amp[stop] - mean_y)
+
+                delta_z = fixed_coordinate[stop] - mean_z
+                mean_z += delta_z / count
+                sum_zz += delta_z * (fixed_coordinate[stop] - mean_z)
+
+                if count < self.min_modes:
+                    continue
+
+                slope = sum_xy / sum_xx
+                log_rmse = math.sqrt(max(sum_zz / count, 0.0))
+                yield FitRangeSelection(
+                    accepted=True,
+                    lower_bound=int(modes[start]),
+                    upper_bound=int(modes[stop]) + 1,
+                    slope=float(slope),
+                    log_rmse=float(log_rmse),
+                )
 
     def _eligible_spectrum(
         self,

--- a/vesmod/EdgeMod/fit_range_selection.py
+++ b/vesmod/EdgeMod/fit_range_selection.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from numbers import Integral, Real
-from typing import Protocol
+from typing import Iterator, Protocol
+import math
 
 import numpy as np
 
@@ -105,9 +106,11 @@ class QMinusThreeFitRangeSelector:
     min_modes : int
         Minimum number of consecutive integer modes in a candidate window.
     slope_tolerance : float
-        Maximum allowed absolute difference between fitted slope and -3.
+        Finite, non-negative maximum absolute difference between fitted slope
+        and -3.
     max_log_rmse : float
-        Maximum allowed RMSE to the fixed q^-3 model in natural-log space.
+        Finite, non-negative maximum RMSE to the fixed q^-3 model in
+        natural-log space.
     """
 
     lower_bound: int
@@ -144,8 +147,12 @@ class QMinusThreeFitRangeSelector:
             raise ValueError("upper_bound must be greater than lower_bound.")
         if self.min_modes < 2:
             raise ValueError("min_modes must be at least 2.")
+        if not math.isfinite(self.slope_tolerance):
+            raise ValueError("slope_tolerance must be finite.")
         if self.slope_tolerance < 0:
             raise ValueError("slope_tolerance must be non-negative.")
+        if not math.isfinite(self.max_log_rmse):
+            raise ValueError("max_log_rmse must be finite.")
         if self.max_log_rmse < 0:
             raise ValueError("max_log_rmse must be non-negative.")
 
@@ -167,51 +174,36 @@ class QMinusThreeFitRangeSelector:
                 ),
             )
 
-        candidates = []
-        for start in range(eligible_modes.size):
-            for stop in range(start + self.min_modes, eligible_modes.size + 1):
-                window_modes = eligible_modes[start:stop]
-                if not np.all(np.diff(window_modes) == 1):
-                    continue
-                window_amps = eligible_amps[start:stop]
-                candidates.append(
-                    self._evaluate_window(window_modes, window_amps)
-                )
+        best_accepted = None
+        best_rejected = None
+        found_candidate = False
+        for candidate in self._iter_candidate_windows(
+            eligible_modes,
+            eligible_amps,
+        ):
+            found_candidate = True
+            if self._is_accepted(candidate):
+                if (
+                    best_accepted is None
+                    or self._accepted_key(candidate) > self._accepted_key(best_accepted)
+                ):
+                    best_accepted = candidate
+            elif (
+                best_rejected is None
+                or self._rejected_key(candidate) < self._rejected_key(best_rejected)
+            ):
+                best_rejected = candidate
 
-        if not candidates:
+        if not found_candidate:
             return FitRangeSelection(
                 accepted=False,
                 lower_bound=None,
                 upper_bound=None,
                 reason="Trusted q range contains no sufficiently long contiguous window.",
             )
+        if best_accepted is not None:
+            return best_accepted
 
-        accepted = [
-            candidate
-            for candidate in candidates
-            if (
-                abs(candidate.slope + 3.0) <= self.slope_tolerance
-                and candidate.log_rmse <= self.max_log_rmse
-            )
-        ]
-        if accepted:
-            return max(
-                accepted,
-                key=lambda candidate: (
-                    candidate.upper_bound - candidate.lower_bound,
-                    -candidate.log_rmse,
-                    -abs(candidate.slope + 3.0),
-                ),
-            )
-
-        best_rejected = min(
-            candidates,
-            key=lambda candidate: (
-                candidate.log_rmse,
-                abs(candidate.slope + 3.0),
-                -(candidate.upper_bound - candidate.lower_bound),
-            ),
-        )
         return FitRangeSelection(
             accepted=False,
             lower_bound=best_rejected.lower_bound,
@@ -219,6 +211,103 @@ class QMinusThreeFitRangeSelector:
             slope=best_rejected.slope,
             log_rmse=best_rejected.log_rmse,
             reason="No trusted q range satisfied the q^-3 scaling criteria.",
+        )
+
+    def _is_accepted(self, candidate: FitRangeSelection) -> bool:
+        """Return whether one evaluated window satisfies both criteria."""
+        return (
+            abs(candidate.slope + 3.0) <= self.slope_tolerance
+            and candidate.log_rmse <= self.max_log_rmse
+        )
+
+    @staticmethod
+    def _accepted_key(candidate: FitRangeSelection) -> tuple[float, ...]:
+        """Return the historical ordering key for accepted windows."""
+        return (
+            candidate.upper_bound - candidate.lower_bound,
+            -candidate.log_rmse,
+            -abs(candidate.slope + 3.0),
+        )
+
+    @staticmethod
+    def _rejected_key(candidate: FitRangeSelection) -> tuple[float, ...]:
+        """Return the historical ordering key for rejected windows."""
+        return (
+            candidate.log_rmse,
+            abs(candidate.slope + 3.0),
+            -(candidate.upper_bound - candidate.lower_bound),
+        )
+
+    def _iter_candidate_windows(
+        self,
+        modes: np.ndarray,
+        avg_amps2: np.ndarray,
+    ) -> Iterator[FitRangeSelection]:
+        """Yield candidate windows using constant-cost prefix-sum statistics."""
+        run_starts = np.concatenate(
+            ([0], np.flatnonzero(np.diff(modes) != 1) + 1)
+        )
+        run_stops = np.concatenate((run_starts[1:], [modes.size]))
+        for run_start, run_stop in zip(run_starts, run_stops, strict=True):
+            if run_stop - run_start < self.min_modes:
+                continue
+            run_modes = modes[run_start:run_stop]
+            run_amps = avg_amps2[run_start:run_stop]
+            yield from self._windows_from_contiguous_run(run_modes, run_amps)
+
+    def _windows_from_contiguous_run(
+        self,
+        modes: np.ndarray,
+        avg_amps2: np.ndarray,
+    ) -> Iterator[FitRangeSelection]:
+        """Yield all sufficiently long windows from one contiguous q run."""
+        log_q = np.log(modes.astype(float))
+        log_amp = np.log(avg_amps2)
+        fixed_residual_coordinate = log_amp + 3.0 * log_q
+        prefixes = tuple(
+            np.concatenate(([0.0], np.cumsum(values)))
+            for values in (
+                log_q,
+                log_amp,
+                log_q * log_q,
+                log_q * log_amp,
+                fixed_residual_coordinate,
+                fixed_residual_coordinate * fixed_residual_coordinate,
+            )
+        )
+        for start in range(modes.size):
+            for stop in range(start + self.min_modes, modes.size + 1):
+                yield self._evaluate_window_from_prefixes(
+                    modes,
+                    start,
+                    stop,
+                    prefixes,
+                )
+
+    @staticmethod
+    def _evaluate_window_from_prefixes(
+        modes: np.ndarray,
+        start: int,
+        stop: int,
+        prefixes: tuple[np.ndarray, ...],
+    ) -> FitRangeSelection:
+        """Evaluate one window in constant time from prefix sums."""
+        sum_x, sum_y, sum_x2, sum_xy, sum_z, sum_z2 = (
+            prefix[stop] - prefix[start]
+            for prefix in prefixes
+        )
+        count = stop - start
+        denominator = count * sum_x2 - sum_x * sum_x
+        slope = (count * sum_xy - sum_x * sum_y) / denominator
+        mean_z = sum_z / count
+        variance_z = max(sum_z2 / count - mean_z * mean_z, 0.0)
+        log_rmse = math.sqrt(variance_z)
+        return FitRangeSelection(
+            accepted=True,
+            lower_bound=int(modes[start]),
+            upper_bound=int(modes[stop - 1]) + 1,
+            slope=float(slope),
+            log_rmse=float(log_rmse),
         )
 
     def _eligible_spectrum(
@@ -242,25 +331,3 @@ class QMinusThreeFitRangeSelector:
         eligible_amps = avg_amps2[mask].astype(float, copy=False)
         order = np.argsort(eligible_modes)
         return eligible_modes[order], eligible_amps[order]
-
-    @staticmethod
-    def _evaluate_window(
-        modes: np.ndarray,
-        avg_amps2: np.ndarray,
-    ) -> FitRangeSelection:
-        """Measure power-law slope and q^-3 residual for one candidate window."""
-        log_q = np.log(modes.astype(float))
-        log_amp = np.log(avg_amps2)
-        slope, _ = np.polyfit(log_q, log_amp, 1)
-
-        log_amplitude = float(np.mean(log_amp + 3.0 * log_q))
-        fixed_model = log_amplitude - 3.0 * log_q
-        log_rmse = float(np.sqrt(np.mean((log_amp - fixed_model) ** 2)))
-
-        return FitRangeSelection(
-            accepted=True,
-            lower_bound=int(modes[0]),
-            upper_bound=int(modes[-1]) + 1,
-            slope=float(slope),
-            log_rmse=log_rmse,
-        )

--- a/vesmod/EdgeMod/fit_range_selection.py
+++ b/vesmod/EdgeMod/fit_range_selection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from numbers import Integral, Real
 from typing import Protocol
 
 import numpy as np
@@ -101,22 +102,42 @@ class QMinusThreeFitRangeSelector:
         Inclusive lowest q value eligible for selection.
     upper_bound : int
         Exclusive highest q value eligible for selection.
-    min_modes : int, default=5
+    min_modes : int
         Minimum number of consecutive integer modes in a candidate window.
-    slope_tolerance : float, default=0.25
+    slope_tolerance : float
         Maximum allowed absolute difference between fitted slope and -3.
-    max_log_rmse : float, default=0.25
+    max_log_rmse : float
         Maximum allowed RMSE to the fixed q^-3 model in natural-log space.
     """
 
     lower_bound: int
     upper_bound: int
-    min_modes: int = 5
-    slope_tolerance: float = 0.25
-    max_log_rmse: float = 0.25
+    min_modes: int
+    slope_tolerance: float
+    max_log_rmse: float
 
     def __post_init__(self) -> None:
         """Validate selector configuration."""
+        if not isinstance(self.lower_bound, Integral) or isinstance(
+            self.lower_bound,
+            bool,
+        ):
+            raise TypeError("lower_bound must be an integer q value.")
+        if not isinstance(self.upper_bound, Integral) or isinstance(
+            self.upper_bound,
+            bool,
+        ):
+            raise TypeError("upper_bound must be an integer q value.")
+        if not isinstance(self.min_modes, Integral) or isinstance(
+            self.min_modes,
+            bool,
+        ):
+            raise TypeError("min_modes must be an integer.")
+        if not isinstance(self.slope_tolerance, Real):
+            raise TypeError("slope_tolerance must be numeric.")
+        if not isinstance(self.max_log_rmse, Real):
+            raise TypeError("max_log_rmse must be numeric.")
+
         if self.lower_bound <= 0:
             raise ValueError("lower_bound must be a positive integer q value.")
         if self.upper_bound <= self.lower_bound:

--- a/vesmod/EdgeMod/fit_range_selection.py
+++ b/vesmod/EdgeMod/fit_range_selection.py
@@ -1,0 +1,245 @@
+"""Select trustworthy q ranges for EdgeMod spectrum fitting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FitRangeSelection:
+    """Result of evaluating a candidate q range for spectrum fitting.
+
+    Parameters
+    ----------
+    accepted : bool
+        Whether the selected range satisfies the selector criteria.
+    lower_bound : int | None
+        Inclusive lower q bound of the selected or best rejected range.
+    upper_bound : int | None
+        Exclusive upper q bound of the selected or best rejected range.
+    slope : float | None
+        Best-fit log-log power-law slope for the reported range.
+    log_rmse : float | None
+        Root-mean-square residual to a fixed q^-3 model in log space.
+    reason : str | None
+        Explanation when no acceptable range is found.
+    """
+
+    accepted: bool
+    lower_bound: int | None
+    upper_bound: int | None
+    slope: float | None = None
+    log_rmse: float | None = None
+    reason: str | None = None
+
+    def to_dict(self) -> dict:
+        """Return JSON-serializable selection diagnostics."""
+        return {
+            "accepted": self.accepted,
+            "lower_bound": self.lower_bound,
+            "upper_bound": self.upper_bound,
+            "slope": self.slope,
+            "log_rmse": self.log_rmse,
+            "reason": self.reason,
+        }
+
+
+class FitRangeSelector(Protocol):
+    """Protocol for strategies that select q ranges from a spectrum."""
+
+    def select(
+        self,
+        modes: np.ndarray,
+        avg_amps2: np.ndarray,
+    ) -> FitRangeSelection:
+        """Return the q range that should be used for physical fitting."""
+
+
+@dataclass(frozen=True)
+class FixedFitRangeSelector:
+    """Select a fixed lower-inclusive, upper-exclusive q range."""
+
+    lower_bound: int
+    upper_bound: int
+
+    def select(
+        self,
+        modes: np.ndarray,
+        avg_amps2: np.ndarray,
+    ) -> FitRangeSelection:
+        """Return the configured range after validating that it is populated."""
+        mask = (modes >= self.lower_bound) & (modes < self.upper_bound)
+        if not np.any(mask):
+            return FitRangeSelection(
+                accepted=False,
+                lower_bound=self.lower_bound,
+                upper_bound=self.upper_bound,
+                reason="Configured q range contains no spectrum modes.",
+            )
+        return FitRangeSelection(
+            accepted=True,
+            lower_bound=self.lower_bound,
+            upper_bound=self.upper_bound,
+        )
+
+
+@dataclass(frozen=True)
+class QMinusThreeFitRangeSelector:
+    """Select the longest trustworthy range consistent with q^-3 scaling.
+
+    Candidate windows are restricted to the configured q interval, evaluated
+    in log space, and required to contain consecutive integer modes. A window
+    is accepted when both its unconstrained power-law slope is sufficiently
+    close to -3 and its residual to a fixed q^-3 model is sufficiently small.
+
+    Parameters
+    ----------
+    lower_bound : int
+        Inclusive lowest q value eligible for selection.
+    upper_bound : int
+        Exclusive highest q value eligible for selection.
+    min_modes : int, default=5
+        Minimum number of consecutive integer modes in a candidate window.
+    slope_tolerance : float, default=0.25
+        Maximum allowed absolute difference between fitted slope and -3.
+    max_log_rmse : float, default=0.25
+        Maximum allowed RMSE to the fixed q^-3 model in natural-log space.
+    """
+
+    lower_bound: int
+    upper_bound: int
+    min_modes: int = 5
+    slope_tolerance: float = 0.25
+    max_log_rmse: float = 0.25
+
+    def __post_init__(self) -> None:
+        """Validate selector configuration."""
+        if self.lower_bound <= 0:
+            raise ValueError("lower_bound must be a positive integer q value.")
+        if self.upper_bound <= self.lower_bound:
+            raise ValueError("upper_bound must be greater than lower_bound.")
+        if self.min_modes < 2:
+            raise ValueError("min_modes must be at least 2.")
+        if self.slope_tolerance < 0:
+            raise ValueError("slope_tolerance must be non-negative.")
+        if self.max_log_rmse < 0:
+            raise ValueError("max_log_rmse must be non-negative.")
+
+    def select(
+        self,
+        modes: np.ndarray,
+        avg_amps2: np.ndarray,
+    ) -> FitRangeSelection:
+        """Return the longest acceptable contiguous q^-3 scaling range."""
+        eligible_modes, eligible_amps = self._eligible_spectrum(modes, avg_amps2)
+        if eligible_modes.size < self.min_modes:
+            return FitRangeSelection(
+                accepted=False,
+                lower_bound=None,
+                upper_bound=None,
+                reason=(
+                    "Trusted q range contains fewer than "
+                    f"{self.min_modes} usable modes."
+                ),
+            )
+
+        candidates = []
+        for start in range(eligible_modes.size):
+            for stop in range(start + self.min_modes, eligible_modes.size + 1):
+                window_modes = eligible_modes[start:stop]
+                if not np.all(np.diff(window_modes) == 1):
+                    continue
+                window_amps = eligible_amps[start:stop]
+                candidates.append(
+                    self._evaluate_window(window_modes, window_amps)
+                )
+
+        if not candidates:
+            return FitRangeSelection(
+                accepted=False,
+                lower_bound=None,
+                upper_bound=None,
+                reason="Trusted q range contains no sufficiently long contiguous window.",
+            )
+
+        accepted = [
+            candidate
+            for candidate in candidates
+            if (
+                abs(candidate.slope + 3.0) <= self.slope_tolerance
+                and candidate.log_rmse <= self.max_log_rmse
+            )
+        ]
+        if accepted:
+            return max(
+                accepted,
+                key=lambda candidate: (
+                    candidate.upper_bound - candidate.lower_bound,
+                    -candidate.log_rmse,
+                    -abs(candidate.slope + 3.0),
+                ),
+            )
+
+        best_rejected = min(
+            candidates,
+            key=lambda candidate: (
+                candidate.log_rmse,
+                abs(candidate.slope + 3.0),
+                -(candidate.upper_bound - candidate.lower_bound),
+            ),
+        )
+        return FitRangeSelection(
+            accepted=False,
+            lower_bound=best_rejected.lower_bound,
+            upper_bound=best_rejected.upper_bound,
+            slope=best_rejected.slope,
+            log_rmse=best_rejected.log_rmse,
+            reason="No trusted q range satisfied the q^-3 scaling criteria.",
+        )
+
+    def _eligible_spectrum(
+        self,
+        modes: np.ndarray,
+        avg_amps2: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return finite positive amplitudes inside the trusted q range."""
+        modes = np.asarray(modes)
+        avg_amps2 = np.asarray(avg_amps2)
+        if modes.shape != avg_amps2.shape:
+            raise ValueError("modes and avg_amps2 must have matching shapes.")
+
+        mask = (
+            (modes >= self.lower_bound)
+            & (modes < self.upper_bound)
+            & np.isfinite(avg_amps2)
+            & (avg_amps2 > 0)
+        )
+        eligible_modes = modes[mask].astype(int, copy=False)
+        eligible_amps = avg_amps2[mask].astype(float, copy=False)
+        order = np.argsort(eligible_modes)
+        return eligible_modes[order], eligible_amps[order]
+
+    @staticmethod
+    def _evaluate_window(
+        modes: np.ndarray,
+        avg_amps2: np.ndarray,
+    ) -> FitRangeSelection:
+        """Measure power-law slope and q^-3 residual for one candidate window."""
+        log_q = np.log(modes.astype(float))
+        log_amp = np.log(avg_amps2)
+        slope, _ = np.polyfit(log_q, log_amp, 1)
+
+        log_amplitude = float(np.mean(log_amp + 3.0 * log_q))
+        fixed_model = log_amplitude - 3.0 * log_q
+        log_rmse = float(np.sqrt(np.mean((log_amp - fixed_model) ** 2)))
+
+        return FitRangeSelection(
+            accepted=True,
+            lower_bound=int(modes[0]),
+            upper_bound=int(modes[-1]) + 1,
+            slope=float(slope),
+            log_rmse=log_rmse,
+        )

--- a/vesmod/EdgeMod/fit_result.py
+++ b/vesmod/EdgeMod/fit_result.py
@@ -1,0 +1,54 @@
+"""Fit-result records for EdgeMod spectrum analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator
+
+from .fit_range_selection import FitRangeSelection
+
+
+@dataclass(frozen=True)
+class SpectrumFit:
+    """Store one physical fit of a Spectrum.
+
+    Parameters
+    ----------
+    kC : float
+        Fitted bending modulus.
+    surface_tension : float
+        Surface tension converted from the fitted reduced tension.
+    lower_bound : int
+        Inclusive lower q bound used for the physical fit.
+    upper_bound : int
+        Exclusive upper q bound used for the physical fit.
+    method : str
+        Human-readable identifier for how the fit range was chosen.
+    range_selection : FitRangeSelection | None
+        Dynamic range-selection diagnostics, when applicable.
+    """
+
+    kC: float
+    surface_tension: float
+    lower_bound: int
+    upper_bound: int
+    method: str
+    range_selection: FitRangeSelection | None = None
+
+    def __iter__(self) -> Iterator[float]:
+        """Preserve legacy ``kc, tension = extract_kc_from_fit(...)`` unpacking."""
+        yield self.kC
+        yield self.surface_tension
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable representation of the fit."""
+        data = {
+            "kC": float(self.kC),
+            "surface_tension": float(self.surface_tension),
+            "lower_bound": self.lower_bound,
+            "upper_bound": self.upper_bound,
+            "method": self.method,
+        }
+        if self.range_selection is not None:
+            data["range_selection"] = self.range_selection.to_dict()
+        return data

--- a/vesmod/EdgeMod/fit_result.py
+++ b/vesmod/EdgeMod/fit_result.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterator
 
+from .config import SpectrumFitConfig
 from .fit_range_selection import FitRangeSelection
 
 
@@ -22,21 +23,26 @@ class SpectrumFit:
         Inclusive lower q bound used for the physical fit.
     upper_bound : int
         Exclusive upper q bound used for the physical fit.
-    method : str
-        Human-readable identifier for how the fit range was chosen.
+    config : SpectrumFitConfig
+        Scientific configuration used to produce this fit.
     range_selection : FitRangeSelection | None
-        Dynamic range-selection diagnostics, when applicable.
+        Range-selection diagnostics associated with the fit.
     """
 
     kC: float
     surface_tension: float
     lower_bound: int
     upper_bound: int
-    method: str
+    config: SpectrumFitConfig
     range_selection: FitRangeSelection | None = None
 
+    @property
+    def method(self) -> str:
+        """Return the class name of the configured q-range selector."""
+        return type(self.config.range_selector).__name__
+
     def __iter__(self) -> Iterator[float]:
-        """Preserve legacy ``kc, tension = extract_kc_from_fit(...)`` unpacking."""
+        """Preserve ``kc, tension = extract_kc_from_fit(...)`` unpacking."""
         yield self.kC
         yield self.surface_tension
 
@@ -48,6 +54,7 @@ class SpectrumFit:
             "lower_bound": self.lower_bound,
             "upper_bound": self.upper_bound,
             "method": self.method,
+            "config": self.config.to_dict(),
         }
         if self.range_selection is not None:
             data["range_selection"] = self.range_selection.to_dict()

--- a/vesmod/EdgeMod/fit_result.py
+++ b/vesmod/EdgeMod/fit_result.py
@@ -1,4 +1,4 @@
-"""Fit-result records for EdgeMod spectrum analysis."""
+"""Immutable fit-result records for EdgeMod spectrum analysis."""
 
 from __future__ import annotations
 
@@ -11,7 +11,12 @@ from .fit_range_selection import FitRangeSelection
 
 @dataclass(frozen=True)
 class SpectrumFit:
-    """Store one physical fit of a Spectrum.
+    """Store one physical fit of a :class:`Spectrum` without overwriting others.
+
+    A ``Spectrum`` may be fit repeatedly with different fixed or dynamic q-range
+    strategies. Each successful fit is represented by its own immutable
+    ``SpectrumFit`` so the fitted values, actual q bounds, scientific config,
+    and range-selection diagnostics remain associated with one another.
 
     Parameters
     ----------
@@ -20,13 +25,16 @@ class SpectrumFit:
     surface_tension : float
         Surface tension converted from the fitted reduced tension.
     lower_bound : int
-        Inclusive lower q bound used for the physical fit.
+        Inclusive lower q bound actually used for the physical fit.
     upper_bound : int
-        Exclusive upper q bound used for the physical fit.
+        Exclusive upper q bound actually used for the physical fit.
     config : SpectrumFitConfig
         Scientific configuration used to produce this fit.
     range_selection : FitRangeSelection | None
-        Range-selection diagnostics associated with the fit.
+        Selector result describing how the q range was chosen. Dynamic
+        selectors additionally report slope, log-space RMSE, and rejection
+        information. Successful physical fits always have an accepted
+        selection.
     """
 
     kC: float
@@ -38,16 +46,16 @@ class SpectrumFit:
 
     @property
     def method(self) -> str:
-        """Return the class name of the configured q-range selector."""
+        """Return the class name of the q-range selector that produced the fit."""
         return type(self.config.range_selector).__name__
 
     def __iter__(self) -> Iterator[float]:
-        """Preserve ``kc, tension = extract_kc_from_fit(...)`` unpacking."""
+        """Allow compatibility unpacking as ``kc, tension = fit``."""
         yield self.kC
         yield self.surface_tension
 
     def to_dict(self) -> dict:
-        """Return a JSON-serializable representation of the fit."""
+        """Return fit values, q bounds, config, and diagnostics for JSON output."""
         data = {
             "kC": float(self.kC),
             "surface_tension": float(self.surface_tension),

--- a/vesmod/EdgeMod/spectrum.py
+++ b/vesmod/EdgeMod/spectrum.py
@@ -11,6 +11,7 @@ import json
 import numpy as np
 from vesmod.VesEdge import VesicleEdges
 from .fit_range_selection import FitRangeSelection, FitRangeSelector
+from .fit_result import SpectrumFit
 from .spectrum_utils import fit_spectrum_to_theory_lmfit, calc_tension_from_reduced_tension, MiniSpectrum
 
 
@@ -52,6 +53,7 @@ class Spectrum:
         self.kC = None
         self.surface_tension = None
         self.fit_range_selection: FitRangeSelection | None = None
+        self.fit_results: list[SpectrumFit] = []
 
     def _calc_avg_sq_amplitudes(self, r_vals_over_time: np.ndarray) -> np.ndarray:
         """Calculate the normalized Fourier transform, then square and average."""
@@ -85,8 +87,12 @@ class Spectrum:
         free_sigma: bool = True,
         temperature: float = 295,
         range_selector: FitRangeSelector | None = None,
-    ) -> tuple[float, float]:
+    ) -> SpectrumFit:
         """Fit a selected mode range to the theoretical prediction.
+
+        Each successful call returns and stores an immutable :class:`SpectrumFit`
+        so multiple fitting strategies can be compared on the same Spectrum.
+        Tuple unpacking remains supported through ``SpectrumFit.__iter__``.
 
         When ``range_selector`` is supplied, it selects the lower-inclusive,
         upper-exclusive q range before the physical fit. A rejected selection
@@ -95,9 +101,12 @@ class Spectrum:
         fixed-range behavior controlled by ``lower_bound`` and ``upper_bound``.
         """
         self.fit_range_selection = None
+        method = "fixed"
+        selection = None
         if range_selector is not None:
             selection = range_selector.select(self.modes, self.avg_amps2)
             self.fit_range_selection = selection
+            method = type(range_selector).__name__
             if not selection.accepted:
                 self.kC = None
                 self.surface_tension = None
@@ -116,7 +125,18 @@ class Spectrum:
             self.kC,
             temperature,
         )
-        return self.kC, self.surface_tension
+        fit_result = SpectrumFit(
+            kC=float(self.kC),
+            surface_tension=float(self.surface_tension),
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+            method=method,
+            range_selection=selection,
+        )
+        if not hasattr(self, "fit_results"):
+            self.fit_results = []
+        self.fit_results.append(fit_result)
+        return fit_result
 
     def _to_dict(self, include_arrays=True) -> dict:
         """Convert class attributes to a dict."""
@@ -129,6 +149,10 @@ class Spectrum:
         selection = getattr(self, "fit_range_selection", None)
         if selection is not None:
             data["fit_range_selection"] = selection.to_dict()
+
+        fit_results = getattr(self, "fit_results", None)
+        if fit_results:
+            data["fit_results"] = [result.to_dict() for result in fit_results]
 
         if include_arrays:
             data["modes"] = (
@@ -146,7 +170,7 @@ class Spectrum:
         include_arrays: bool = True,
         indent: int = 2,
     ) -> None:
-        """Save class attributes to JSON."""
+        """Save class attributes and all stored fit results to JSON."""
         outfile = Path(outfile).with_suffix('.json')
         with outfile.open("w", encoding="utf-8") as f:
             json.dump(self._to_dict(include_arrays=include_arrays), f, indent=indent)

--- a/vesmod/EdgeMod/spectrum.py
+++ b/vesmod/EdgeMod/spectrum.py
@@ -10,6 +10,7 @@ from types import NoneType
 import json
 import numpy as np
 from vesmod.VesEdge import VesicleEdges
+from .fit_range_selection import FitRangeSelection, FitRangeSelector
 from .spectrum_utils import fit_spectrum_to_theory_lmfit, calc_tension_from_reduced_tension, MiniSpectrum
 
 
@@ -50,6 +51,7 @@ class Spectrum:
         self.modes = self._calc_integer_modes()
         self.kC = None
         self.surface_tension = None
+        self.fit_range_selection: FitRangeSelection | None = None
 
     def _calc_avg_sq_amplitudes(self, r_vals_over_time: np.ndarray) -> np.ndarray:
         """Calculate the normalized Fourier transform, then square and average."""
@@ -81,9 +83,30 @@ class Spectrum:
         upper_bound: int = 8,
         lmax: int = 500,
         free_sigma: bool = True,
-        temperature: float = 295
+        temperature: float = 295,
+        range_selector: FitRangeSelector | None = None,
     ) -> tuple[float, float]:
-        """Fit a selected mode range to the theoretical prediction."""
+        """Fit a selected mode range to the theoretical prediction.
+
+        When ``range_selector`` is supplied, it selects the lower-inclusive,
+        upper-exclusive q range before the physical fit. A rejected selection
+        raises ``ValueError`` and leaves its diagnostics on
+        ``fit_range_selection``. Omitting the selector preserves the existing
+        fixed-range behavior controlled by ``lower_bound`` and ``upper_bound``.
+        """
+        self.fit_range_selection = None
+        if range_selector is not None:
+            selection = range_selector.select(self.modes, self.avg_amps2)
+            self.fit_range_selection = selection
+            if not selection.accepted:
+                self.kC = None
+                self.surface_tension = None
+                raise ValueError(selection.reason or "No acceptable q range found.")
+            if selection.lower_bound is None or selection.upper_bound is None:
+                raise ValueError("Accepted fit-range selection is missing q bounds.")
+            lower_bound = selection.lower_bound
+            upper_bound = selection.upper_bound
+
         fitting_range = self.isolate_mode_range(lower_bound, upper_bound)
         fit = fit_spectrum_to_theory_lmfit(fitting_range, lmax, free_sigma)
         self.kC, reduced_sigma = fit
@@ -102,6 +125,10 @@ class Spectrum:
             "kC": float(self.kC) if getattr(self, "kC", None) is not None else None,
             "surface_tension": float(self.surface_tension) if getattr(self, "surface_tension", None) is not None else None,
         }
+
+        selection = getattr(self, "fit_range_selection", None)
+        if selection is not None:
+            data["fit_range_selection"] = selection.to_dict()
 
         if include_arrays:
             data["modes"] = (

--- a/vesmod/EdgeMod/spectrum.py
+++ b/vesmod/EdgeMod/spectrum.py
@@ -10,9 +10,14 @@ from types import NoneType
 import json
 import numpy as np
 from vesmod.VesEdge import VesicleEdges
-from .fit_range_selection import FitRangeSelection, FitRangeSelector
+from .config import SpectrumFitConfig
+from .fit_range_selection import FitRangeSelection
 from .fit_result import SpectrumFit
-from .spectrum_utils import fit_spectrum_to_theory_lmfit, calc_tension_from_reduced_tension, MiniSpectrum
+from .spectrum_utils import (
+    MiniSpectrum,
+    calc_tension_from_reduced_tension,
+    fit_spectrum_to_theory_lmfit,
+)
 
 
 class Spectrum:
@@ -77,61 +82,73 @@ class Spectrum:
         mask1 = self.modes >= lower_bound
         mask2 = self.modes < upper_bound
         combined_mask = mask1 & mask2
-        return MiniSpectrum(self.modes[combined_mask], self.avg_amps2[combined_mask], None)
+        return MiniSpectrum(
+            self.modes[combined_mask],
+            self.avg_amps2[combined_mask],
+            None,
+        )
 
-    def extract_kc_from_fit(  # pylint: disable=too-many-arguments
+    def extract_kc_from_fit(
         self,
-        lower_bound: int = 3,
-        upper_bound: int = 8,
-        *,
-        lmax: int = 500,
-        free_sigma: bool = True,
-        temperature: float = 295,
-        range_selector: FitRangeSelector | None = None,
+        config: SpectrumFitConfig | None = None,
     ) -> SpectrumFit:
-        """Fit a selected mode range to the theoretical prediction.
+        """Fit a configured mode range to the theoretical prediction.
 
-        Each successful call returns and stores an immutable :class:`SpectrumFit`
-        so multiple fitting strategies can be compared on the same Spectrum.
-        Tuple unpacking remains supported through ``SpectrumFit.__iter__``.
+        Parameters
+        ----------
+        config : SpectrumFitConfig | None
+            Scientific fit configuration. If omitted, use the default fixed
+            q=3--7 fit with the standard EdgeMod settings.
 
-        When ``range_selector`` is supplied, it selects the lower-inclusive,
-        upper-exclusive q range before the physical fit. A rejected selection
-        raises ``ValueError`` and leaves its diagnostics on
-        ``fit_range_selection``. Omitting the selector preserves the existing
-        fixed-range behavior controlled by ``lower_bound`` and ``upper_bound``.
+        Returns
+        -------
+        SpectrumFit
+            Immutable fit result containing the fitted values, q bounds, and
+            configuration used to produce them.
+
+        Raises
+        ------
+        ValueError
+            If the configured range selector rejects the spectrum.
         """
-        self.fit_range_selection = None
-        method = "fixed"
-        selection = None
-        if range_selector is not None:
-            selection = range_selector.select(self.modes, self.avg_amps2)
-            self.fit_range_selection = selection
-            method = type(range_selector).__name__
-            if not selection.accepted:
-                self.kC = None
-                self.surface_tension = None
-                raise ValueError(selection.reason or "No acceptable q range found.")
-            if selection.lower_bound is None or selection.upper_bound is None:
-                raise ValueError("Accepted fit-range selection is missing q bounds.")
-            lower_bound = selection.lower_bound
-            upper_bound = selection.upper_bound
+        if config is None:
+            config = SpectrumFitConfig()
+        if not isinstance(config, SpectrumFitConfig):
+            raise TypeError("config must be a SpectrumFitConfig or None.")
 
-        fitting_range = self.isolate_mode_range(lower_bound, upper_bound)
-        fit = fit_spectrum_to_theory_lmfit(fitting_range, lmax, free_sigma)
-        self.kC, reduced_sigma = fit
+        selection = config.range_selector.select(
+            self.modes,
+            self.avg_amps2,
+        )
+        self.fit_range_selection = selection
+        if not selection.accepted:
+            self.kC = None
+            self.surface_tension = None
+            raise ValueError(selection.reason or "No acceptable q range found.")
+        if selection.lower_bound is None or selection.upper_bound is None:
+            raise ValueError("Accepted fit-range selection is missing q bounds.")
+
+        fitting_range = self.isolate_mode_range(
+            selection.lower_bound,
+            selection.upper_bound,
+        )
+        self.kC, reduced_sigma = fit_spectrum_to_theory_lmfit(
+            fitting_range,
+            config.lmax,
+            config.free_sigma,
+        )
         self.surface_tension = calc_tension_from_reduced_tension(
             self.r0,
             reduced_sigma,
             self.kC,
-            temperature,
+            config.temperature,
         )
         fit_result = SpectrumFit(
             kC=float(self.kC),
             surface_tension=float(self.surface_tension),
-            lower_bound=lower_bound,
-            upper_bound=upper_bound,
-            method=method,
+            lower_bound=selection.lower_bound,
+            upper_bound=selection.upper_bound,
+            config=config,
             range_selection=selection,
         )
         if not hasattr(self, "fit_results"):
@@ -144,7 +161,11 @@ class Spectrum:
         data = {
             "r0": float(self.r0) if getattr(self, "r0", None) is not None else None,
             "kC": float(self.kC) if getattr(self, "kC", None) is not None else None,
-            "surface_tension": float(self.surface_tension) if getattr(self, "surface_tension", None) is not None else None,
+            "surface_tension": (
+                float(self.surface_tension)
+                if getattr(self, "surface_tension", None) is not None
+                else None
+            ),
         }
 
         selection = getattr(self, "fit_range_selection", None)
@@ -157,10 +178,14 @@ class Spectrum:
 
         if include_arrays:
             data["modes"] = (
-                self.modes.tolist() if getattr(self, "modes", None) is not None else None
+                self.modes.tolist()
+                if getattr(self, "modes", None) is not None
+                else None
             )
             data["avg_amps2"] = (
-                self.avg_amps2.tolist() if getattr(self, "avg_amps2", None) is not None else None
+                self.avg_amps2.tolist()
+                if getattr(self, "avg_amps2", None) is not None
+                else None
             )
 
         return data

--- a/vesmod/EdgeMod/spectrum.py
+++ b/vesmod/EdgeMod/spectrum.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Created on Tue Jan 21 15:04:46 2025.
+"""Compute vesicle fluctuation spectra and fit membrane mechanical parameters."""
 
-@author: js2746
-"""
 from pathlib import Path
 from types import NoneType
 import json
@@ -21,14 +18,34 @@ from .spectrum_utils import (
 
 
 class Spectrum:
-    """Calculate the fluctuation spectrum of a vesicle edge trajectory."""
+    """Represent one measured vesicle fluctuation spectrum and its fit history.
+
+    ``Spectrum`` stores the measured Fourier modes and mean-squared amplitudes.
+    Scientific fitting choices are supplied separately through
+    :class:`SpectrumFitConfig`, allowing the same measured spectrum to be fit
+    repeatedly with fixed or dynamically selected q ranges. Successful fits are
+    retained in ``fit_results`` rather than replacing one another.
+
+    ``kC`` and ``surface_tension`` remain convenience attributes containing the
+    most recent successful fit values.
+    """
 
     def __init__(
         self,
         edges_over_time: str | Path | VesicleEdges,
         frame_cutoff=None
     ) -> None:
-        """Create a Spectrum from accepted radii or a QCed VesicleEdges object."""
+        """Create a spectrum from accepted contour radii.
+
+        Parameters
+        ----------
+        edges_over_time : str | Path | VesicleEdges
+            A ``.npy`` trajectory of contour radii in microns or a QC-completed
+            ``VesicleEdges`` object. Only accepted detections from
+            ``VesicleEdges`` contribute to the spectrum.
+        frame_cutoff : int | None, optional
+            If provided, use only the first ``frame_cutoff`` contour frames.
+        """
         if isinstance(edges_over_time, VesicleEdges):
             input_data = edges_over_time.accepted_radii_microns
         elif isinstance(edges_over_time, (Path, str)):
@@ -61,7 +78,7 @@ class Spectrum:
         self.fit_results: list[SpectrumFit] = []
 
     def _calc_avg_sq_amplitudes(self, r_vals_over_time: np.ndarray) -> np.ndarray:
-        """Calculate the normalized Fourier transform, then square and average."""
+        """Return frame-averaged squared Fourier amplitudes normalized by r0."""
         n_samples = r_vals_over_time.shape[1]
         norm = 1. / (self.r0 * n_samples)
         amps = np.fft.fft(r_vals_over_time, axis=1, norm='backward') * norm
@@ -70,13 +87,13 @@ class Spectrum:
         return avg_amps2
 
     def _calc_integer_modes(self) -> np.ndarray[int]:
-        """Calculate integer Fourier modes q for the spectrum."""
+        """Return integer Fourier mode numbers in NumPy FFT ordering."""
         freqs = np.fft.fftfreq(self.avg_amps2.shape[0])
         modes = np.round(freqs * self.avg_amps2.shape[0]).astype(int)
         return modes
 
     def isolate_mode_range(self, lower_bound: int, upper_bound: int) -> MiniSpectrum:
-        """Return modes >= lower_bound and < upper_bound with amplitudes."""
+        """Return modes with ``lower_bound <= q < upper_bound`` and amplitudes."""
         if self.modes is None:
             raise AttributeError("There are no modes; Cannot return mode range.")
         mask1 = self.modes >= lower_bound
@@ -92,24 +109,30 @@ class Spectrum:
         self,
         config: SpectrumFitConfig | None = None,
     ) -> SpectrumFit:
-        """Fit a configured mode range to the theoretical prediction.
+        """Select a q range and fit that range to the theoretical spectrum.
 
         Parameters
         ----------
         config : SpectrumFitConfig | None
-            Scientific fit configuration. If omitted, use the default fixed
-            q=3--7 fit with the standard EdgeMod settings.
+            Scientific fit configuration. If omitted, use the historical
+            default fixed fit over q = 3, 4, 5, 6, 7 with ``lmax=500``, free
+            surface tension, and ``temperature=295 K``.
 
         Returns
         -------
         SpectrumFit
-            Immutable fit result containing the fitted values, q bounds, and
-            configuration used to produce them.
+            Immutable fit result containing fitted values, the actual q bounds
+            used, the full configuration, and range-selection diagnostics. The
+            result is appended to ``fit_results``.
 
         Raises
         ------
+        TypeError
+            If ``config`` is not a ``SpectrumFitConfig`` or ``None``.
         ValueError
-            If the configured range selector rejects the spectrum.
+            If the configured range selector rejects the spectrum or returns an
+            accepted selection without q bounds. Dynamic rejection occurs
+            before the physical spectrum fit is run.
         """
         if config is None:
             config = SpectrumFitConfig()
@@ -157,7 +180,7 @@ class Spectrum:
         return fit_result
 
     def _to_dict(self, include_arrays=True) -> dict:
-        """Convert class attributes to a dict."""
+        """Return spectrum state and retained fit results as serializable data."""
         data = {
             "r0": float(self.r0) if getattr(self, "r0", None) is not None else None,
             "kC": float(self.kC) if getattr(self, "kC", None) is not None else None,
@@ -196,7 +219,7 @@ class Spectrum:
         include_arrays: bool = True,
         indent: int = 2,
     ) -> None:
-        """Save class attributes and all stored fit results to JSON."""
+        """Write spectrum data and all retained fit results to a JSON file."""
         outfile = Path(outfile).with_suffix('.json')
         with outfile.open("w", encoding="utf-8") as f:
             json.dump(self._to_dict(include_arrays=include_arrays), f, indent=indent)

--- a/vesmod/EdgeMod/spectrum.py
+++ b/vesmod/EdgeMod/spectrum.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Compute vesicle fluctuation spectra and fit membrane mechanical parameters."""
+"""Calculate and fit vesicle fluctuation spectra.
 
+``Spectrum`` converts accepted vesicle contours into a fluctuation spectrum and
+fits a q range selected by a :class:`SpectrumFitConfig`. Fixed and dynamic
+range-selection strategies share the same fitting path. Each successful fit is
+retained as an immutable :class:`SpectrumFit` so multiple analyses of one
+spectrum can be compared without overwriting earlier results.
+"""
 from pathlib import Path
 from types import NoneType
 import json
@@ -18,16 +24,12 @@ from .spectrum_utils import (
 
 
 class Spectrum:
-    """Represent one measured vesicle fluctuation spectrum and its fit history.
+    """Calculate and fit the fluctuation spectrum of one vesicle trajectory.
 
-    ``Spectrum`` stores the measured Fourier modes and mean-squared amplitudes.
-    Scientific fitting choices are supplied separately through
-    :class:`SpectrumFitConfig`, allowing the same measured spectrum to be fit
-    repeatedly with fixed or dynamically selected q ranges. Successful fits are
-    retained in ``fit_results`` rather than replacing one another.
-
-    ``kC`` and ``surface_tension`` remain convenience attributes containing the
-    most recent successful fit values.
+    ``kC`` and ``surface_tension`` are compatibility attributes containing the
+    most recent *successful* physical fit. Range-selection failures update
+    ``fit_range_selection`` but leave those latest-successful values unchanged.
+    Durable per-fit provenance is stored in ``fit_results``.
     """
 
     def __init__(
@@ -35,17 +37,7 @@ class Spectrum:
         edges_over_time: str | Path | VesicleEdges,
         frame_cutoff=None
     ) -> None:
-        """Create a spectrum from accepted contour radii.
-
-        Parameters
-        ----------
-        edges_over_time : str | Path | VesicleEdges
-            A ``.npy`` trajectory of contour radii in microns or a QC-completed
-            ``VesicleEdges`` object. Only accepted detections from
-            ``VesicleEdges`` contribute to the spectrum.
-        frame_cutoff : int | None, optional
-            If provided, use only the first ``frame_cutoff`` contour frames.
-        """
+        """Create a Spectrum from accepted radii or a QCed VesicleEdges object."""
         if isinstance(edges_over_time, VesicleEdges):
             input_data = edges_over_time.accepted_radii_microns
         elif isinstance(edges_over_time, (Path, str)):
@@ -131,8 +123,9 @@ class Spectrum:
             If ``config`` is not a ``SpectrumFitConfig`` or ``None``.
         ValueError
             If the configured range selector rejects the spectrum or returns an
-            accepted selection without q bounds. Dynamic rejection occurs
-            before the physical spectrum fit is run.
+            accepted selection without q bounds. A rejection updates
+            ``fit_range_selection`` but does not replace the most recent
+            successful ``kC`` or ``surface_tension`` values.
         """
         if config is None:
             config = SpectrumFitConfig()
@@ -145,8 +138,6 @@ class Spectrum:
         )
         self.fit_range_selection = selection
         if not selection.accepted:
-            self.kC = None
-            self.surface_tension = None
             raise ValueError(selection.reason or "No acceptable q range found.")
         if selection.lower_bound is None or selection.upper_bound is None:
             raise ValueError("Accepted fit-range selection is missing q bounds.")
@@ -155,20 +146,22 @@ class Spectrum:
             selection.lower_bound,
             selection.upper_bound,
         )
-        self.kC, reduced_sigma = fit_spectrum_to_theory_lmfit(
+        fitted_kc, reduced_sigma = fit_spectrum_to_theory_lmfit(
             fitting_range,
             config.lmax,
             config.free_sigma,
         )
-        self.surface_tension = calc_tension_from_reduced_tension(
+        fitted_surface_tension = calc_tension_from_reduced_tension(
             self.r0,
             reduced_sigma,
-            self.kC,
+            fitted_kc,
             config.temperature,
         )
+        self.kC = fitted_kc
+        self.surface_tension = fitted_surface_tension
         fit_result = SpectrumFit(
-            kC=float(self.kC),
-            surface_tension=float(self.surface_tension),
+            kC=float(fitted_kc),
+            surface_tension=float(fitted_surface_tension),
             lower_bound=selection.lower_bound,
             upper_bound=selection.upper_bound,
             config=config,
@@ -180,7 +173,7 @@ class Spectrum:
         return fit_result
 
     def _to_dict(self, include_arrays=True) -> dict:
-        """Return spectrum state and retained fit results as serializable data."""
+        """Return spectrum state and retained fit provenance as a dictionary."""
         data = {
             "r0": float(self.r0) if getattr(self, "r0", None) is not None else None,
             "kC": float(self.kC) if getattr(self, "kC", None) is not None else None,
@@ -219,7 +212,7 @@ class Spectrum:
         include_arrays: bool = True,
         indent: int = 2,
     ) -> None:
-        """Write spectrum data and all retained fit results to a JSON file."""
+        """Serialize spectrum state and retained fit records to JSON."""
         outfile = Path(outfile).with_suffix('.json')
         with outfile.open("w", encoding="utf-8") as f:
             json.dump(self._to_dict(include_arrays=include_arrays), f, indent=indent)

--- a/vesmod/EdgeMod/spectrum.py
+++ b/vesmod/EdgeMod/spectrum.py
@@ -79,10 +79,11 @@ class Spectrum:
         combined_mask = mask1 & mask2
         return MiniSpectrum(self.modes[combined_mask], self.avg_amps2[combined_mask], None)
 
-    def extract_kc_from_fit(
+    def extract_kc_from_fit(  # pylint: disable=too-many-arguments
         self,
         lower_bound: int = 3,
         upper_bound: int = 8,
+        *,
         lmax: int = 500,
         free_sigma: bool = True,
         temperature: float = 295,

--- a/vesmod/EdgeMod/spectrum_ensemble.py
+++ b/vesmod/EdgeMod/spectrum_ensemble.py
@@ -1,38 +1,28 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Tools for averaging fluctuation spectra across multiple replicas.
+"""Tools for averaging fluctuation spectra across multiple replicas.
 
-This module provides the SpectrumEnsemble class, which aggregates
-Spectrum objects and bending modulus estimates from multiple replicas
-of the same system. The class calculates ensemble-averaged squared
-amplitudes, replica-to-replica uncertainty estimates, and an
-overall bending modulus obtained by fitting the averaged spectrum
-to the theoretical fluctuation model.
+``SpectrumEnsemble`` aggregates spectra and bending-modulus estimates from
+replicas of the same system. It computes ensemble-averaged squared amplitudes,
+replica-to-replica uncertainty estimates, and a bending modulus from a fixed
+q-range fit of the averaged spectrum.
 
-Typical usage consists of adding one Spectrum per replica using
-:add_spectrum:, then accessing the averaged amplitudes through
-:attr:`avg_amps2` or the fitted bending modulus through
-:attr:`kC`.
+Dynamic q-range selection introduced for ``Spectrum`` is not applied
+implicitly to ensemble fits; ensemble fitting retains its existing fixed-range
+behavior.
 """
 import numpy as np
 from vesmod.EdgeMod.spectrum_utils import fit_spectrum_to_theory_lmfit, MiniSpectrum
 
 
 class SpectrumEnsemble:
-    """
-    Store and analyze fluctuation spectra from multiple replicas.
+    """Store and analyze fluctuation spectra from multiple replicas.
 
-    Each replica contributes a spectrum of average squared mode
-    amplitudes and an independently determined bending modulus.
-    All spectra must be defined on the same set of Fourier modes.
+    Each replica contributes average squared mode amplitudes and an independently
+    determined bending modulus. All spectra must use the same Fourier modes.
 
-    The class provides properties for calculating:
-
-    * Ensemble-averaged squared amplitudes.
-    * Standard deviations and standard errors across replicas.
-    * Mean bending modulus obtained by fitting the averaged spectrum.
-    * Uncertainty estimates based on replica-to-replica variation.
+    The ensemble provides averaged amplitudes, replica dispersion/error, and a
+    fixed-range fit of the ensemble-averaged spectrum.
 
     Attributes
     ----------
@@ -41,8 +31,8 @@ class SpectrumEnsemble:
     kC_list : list[float]
         Bending modulus estimate associated with each replica.
     modes : np.ndarray or None
-        Fourier mode indices shared by all stored spectra.
-        Set automatically when the first spectrum is added.
+        Fourier mode indices shared by all stored spectra. Set automatically
+        when the first spectrum is added.
     """
 
     def __init__(self) -> None:
@@ -51,68 +41,58 @@ class SpectrumEnsemble:
         self.modes: np.ndarray[int] = None
 
     def __len__(self) -> int:
-        """Return length of kC_list."""
+        """Return the number of replica bending-modulus estimates."""
         return len(self.kC_list)
 
     @property
     def avg_amps2(self) -> np.ndarray:
-        """Return mean of spectra_list along time dimension."""
+        """Return the mean squared fluctuation amplitudes across replicas."""
         return np.mean(np.array(self.spectra_list), axis=0)
 
     @property
     def avg_amps2_std(self) -> np.ndarray:
-        """Take standard deviation of spectra_list along time dimension."""
+        """Return the sample standard deviation of amplitudes across replicas."""
         return np.std(np.array(self.spectra_list), axis=0, ddof=1)
 
     @property
     def avg_amps2_ste(self) -> np.ndarray:
-        """Calculate standard error."""
+        """Return the standard error of amplitudes across replicas."""
         return self.avg_amps2_std / np.sqrt(len(self.spectra_list))
 
     @property
     def kC(self) -> float:
-        """Calculate kC from fit."""
+        """Return kC from the default fixed-range fit of the averaged spectrum."""
         return self._extract_kC_from_fit()
 
     @property
     def kC_std(self) -> float:
-        """Calculate standard deviation from dispersion among replica kC values."""
+        """Return sample standard deviation among replica kC values."""
         return np.std(self.kC_list, ddof=1)
 
     @property
     def kC_ste(self) -> float:
-        """Calculate standard error."""
+        """Return standard error among replica kC values."""
         return self.kC_std / np.sqrt(len(self.kC_list))
 
     def add_spectrum(self, avg_amps2: list[float], modes: list[int], kC: float) -> None:
-        """
-        Add a spectrum replica to the ensemble.
+        """Add one replica spectrum and its fitted bending modulus.
 
         Parameters
         ----------
         avg_amps2 : array-like of float
             Average squared fluctuation amplitudes for each Fourier mode.
         modes : array-like of int
-            Fourier mode indices corresponding to ``avg_amps2``.
-            The mode array must match that of all previously added
-            spectra.
+            Fourier mode indices corresponding to ``avg_amps2``. The mode array
+            must match all previously added spectra.
         kC : float
-            Bending modulus determined from this replica.
+            Bending modulus determined independently for this replica.
 
         Raises
         ------
         ValueError
-            If ``modes`` does not match the mode indices already stored
-            in the object.
+            If ``modes`` does not match the mode indices already stored.
         TypeError
             If ``self.modes`` is neither ``None`` nor a NumPy array.
-
-        Notes
-        -----
-        The first spectrum added defines the mode indices used by the
-        ensemble. All subsequent spectra must use the same modes so that
-        replica averages can be computed element-wise.
-
         """
         if isinstance(self.modes, np.ndarray):
             if not np.array_equal(np.array(modes), self.modes):
@@ -125,15 +105,7 @@ class SpectrumEnsemble:
         self.kC_list.append(kC)
 
     def _isolate_mode_range(self, lower_bound: int, upper_bound: int) -> MiniSpectrum:
-        """
-        Return all modes greater than or equal to lower_bound and less than \
-        upper_bound, and their associated avg squared amplitudes.
-
-        Returns
-        -------
-        MiniSpectrum : namedtuple
-
-        """
+        """Return ensemble modes with ``lower_bound <= q < upper_bound``."""
         if self.modes is None:
             raise AttributeError("There are no modes; Cannot return mode range.")
         mask1 = self.modes >= lower_bound
@@ -146,25 +118,23 @@ class SpectrumEnsemble:
         lower_bound: int = 3,
         upper_bound: int = 8,
         lmax: int = 500,
-    ) -> tuple[float, float]:
-        """
-        Fit specific range of self.avg_amps2 to theoretical prediction.
+    ) -> float:
+        """Fit a fixed q range of the averaged spectrum with sigma fixed to zero.
 
         Parameters
         ----------
-        lower_bound, upper_bound : ints
-            Fit modes greater than or equal to lower_bound and less than upper_bound.
-        lmax : int
-            Maximum iteration index in theoretical summation. Default is 500.
-        free_sigma : bool
-            If True, allow surface tension (sigma) to vary. If False, set sigma
-            to zero and do not let it vary during fitting.
+        lower_bound : int, default=3
+            Inclusive lower Fourier mode used in the ensemble fit.
+        upper_bound : int, default=8
+            Exclusive upper Fourier mode used in the ensemble fit.
+        lmax : int, default=500
+            Maximum summation index in the theoretical spectrum model.
 
         Returns
         -------
         float
-            The best fitting kC within the fitting range with sigma set to 0.
-
+            Best-fitting bending modulus for the averaged spectrum with reduced
+            surface tension fixed to zero.
         """
         fitting_range = self._isolate_mode_range(lower_bound, upper_bound)
         fit = fit_spectrum_to_theory_lmfit(fitting_range, lmax, free_sigma=False)

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from vesmod.EdgeMod import Spectrum
+from vesmod.EdgeMod import (
+    FixedFitRangeSelector,
+    QMinusThreeFitRangeSelector,
+    Spectrum,
+    SpectrumFitConfig,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -30,13 +35,39 @@ def parse_args() -> argparse.Namespace:
         "--lower-fitting-bound",
         type=int,
         default=3,
-        help="Lowest Fourier mode included in the fit. Default: 3.",
+        help=(
+            "Lowest Fourier mode included in a fixed fit or eligible for "
+            "dynamic selection. Default: 3."
+        ),
     )
     parser.add_argument(
         "--upper-fitting-bound",
         type=int,
         default=8,
-        help="First Fourier mode excluded from the fit. Default: 8.",
+        help=(
+            "First Fourier mode excluded from a fixed fit or dynamic-search "
+            "interval. Default: 8."
+        ),
+    )
+    parser.add_argument(
+        "--dynamic-range",
+        action="store_true",
+        help="Select the fit range from q^-3 scaling instead of using fixed bounds.",
+    )
+    parser.add_argument(
+        "--min-modes",
+        type=int,
+        help="Minimum consecutive q modes required for dynamic selection.",
+    )
+    parser.add_argument(
+        "--slope-tolerance",
+        type=float,
+        help="Maximum allowed absolute deviation of the fitted slope from -3.",
+    )
+    parser.add_argument(
+        "--max-log-rmse",
+        type=float,
+        help="Maximum allowed log-space RMSE to a fixed q^-3 model.",
     )
     parser.add_argument(
         "--lmax",
@@ -73,21 +104,60 @@ def iter_npy_files(input_path: Path, recursive: bool) -> list[Path]:
     return sorted(input_path.glob(pattern))
 
 
+def build_fit_config(args: argparse.Namespace) -> SpectrumFitConfig:
+    """Build the scientific fit configuration requested on the command line."""
+    if args.dynamic_range:
+        missing = [
+            option
+            for option, value in (
+                ("--min-modes", args.min_modes),
+                ("--slope-tolerance", args.slope_tolerance),
+                ("--max-log-rmse", args.max_log_rmse),
+            )
+            if value is None
+        ]
+        if missing:
+            raise ValueError(
+                "Dynamic range selection requires " + ", ".join(missing) + "."
+            )
+        range_selector = QMinusThreeFitRangeSelector(
+            lower_bound=args.lower_fitting_bound,
+            upper_bound=args.upper_fitting_bound,
+            min_modes=args.min_modes,
+            slope_tolerance=args.slope_tolerance,
+            max_log_rmse=args.max_log_rmse,
+        )
+    else:
+        range_selector = FixedFitRangeSelector(
+            lower_bound=args.lower_fitting_bound,
+            upper_bound=args.upper_fitting_bound,
+        )
+
+    return SpectrumFitConfig(
+        lmax=args.lmax,
+        free_sigma=not args.fixed_sigma,
+        temperature=args.temperature,
+        range_selector=range_selector,
+    )
+
+
+def output_path_for(path: Path, dynamic_range: bool) -> Path:
+    """Return a non-colliding JSON path for the requested fit strategy."""
+    if dynamic_range:
+        return path.with_name(f"{path.stem}.dynamic.json")
+    return path.with_suffix(".json")
+
+
 def process_file(path: Path, args: argparse.Namespace) -> None:
     """Fit one edge file and save its spectrum metadata to JSON."""
-    output_path = path.with_suffix(".json")
+    config = build_fit_config(args)
+    output_path = output_path_for(path, args.dynamic_range)
 
     print(f"Working on file {path.stem}")
     spectrum = Spectrum(path)
-    kc, sigma = spectrum.extract_kc_from_fit(
-        lower_bound=args.lower_fitting_bound,
-        upper_bound=args.upper_fitting_bound,
-        lmax=args.lmax,
-        free_sigma=not args.fixed_sigma,
-        temperature=args.temperature
-    )
-    print(f"kc={kc}, sigma={sigma}")
-    spectrum.to_json(path)
+    fit = spectrum.extract_kc_from_fit(config)
+    print(f"kc={fit.kC}, sigma={fit.surface_tension}")
+    spectrum.to_json(output_path)
 
 
 def main() -> None:

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -1,4 +1,10 @@
-"""Command line tool for fitting bending moduli from vesicle edge arrays."""
+"""CLI for fixed or dynamically selected EdgeMod spectrum fitting.
+
+The command-line layer converts user options into a ``SpectrumFitConfig`` and
+then delegates scientific analysis to ``Spectrum``. Fixed fitting remains the
+default; dynamic fitting uses q^-3 scaling criteria supplied explicitly by the
+user and writes a distinct ``.dynamic.json`` output.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +20,7 @@ from vesmod.EdgeMod import (
 
 
 def parse_args() -> argparse.Namespace:
-    """Parse command line arguments."""
+    """Parse input-selection, physical-fit, and q-range-selection options."""
     parser = argparse.ArgumentParser(
         description=(
             "Fit kc/sigma from one or more .npy edge files and write one JSON "
@@ -90,7 +96,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def iter_npy_files(input_path: Path, recursive: bool) -> list[Path]:
-    """Return the .npy files selected by the user."""
+    """Return the input ``.npy`` files selected by a CLI path and recursion flag."""
     input_path = input_path.expanduser().resolve()
     if input_path.is_file():
         if input_path.suffix != ".npy":
@@ -105,7 +111,12 @@ def iter_npy_files(input_path: Path, recursive: bool) -> list[Path]:
 
 
 def build_fit_config(args: argparse.Namespace) -> SpectrumFitConfig:
-    """Build the scientific fit configuration requested on the command line."""
+    """Translate parsed CLI options into one scientific fit configuration.
+
+    Fixed mode constructs a ``FixedFitRangeSelector``. Dynamic mode constructs
+    a ``QMinusThreeFitRangeSelector`` and requires all three empirical
+    acceptance criteria to be supplied explicitly.
+    """
     if args.dynamic_range:
         missing = [
             option
@@ -142,14 +153,14 @@ def build_fit_config(args: argparse.Namespace) -> SpectrumFitConfig:
 
 
 def output_path_for(path: Path, dynamic_range: bool) -> Path:
-    """Return a non-colliding JSON path for the requested fit strategy."""
+    """Return the JSON output path, separating dynamic from fixed results."""
     if dynamic_range:
         return path.with_name(f"{path.stem}.dynamic.json")
     return path.with_suffix(".json")
 
 
 def process_file(path: Path, args: argparse.Namespace) -> None:
-    """Fit one edge file and save its spectrum metadata to JSON."""
+    """Fit one contour trajectory with the requested config and write JSON."""
     config = build_fit_config(args)
     output_path = output_path_for(path, args.dynamic_range)
 
@@ -161,7 +172,7 @@ def process_file(path: Path, args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    """Run the command line interface."""
+    """Run EdgeMod over the selected file or batch of files."""
     args = parse_args()
     paths = iter_npy_files(args.input_path, args.recursive)
     if not paths:

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -3,7 +3,9 @@
 The command-line layer converts user options into a ``SpectrumFitConfig`` and
 then delegates scientific analysis to ``Spectrum``. Fixed fitting remains the
 default; dynamic fitting uses q^-3 scaling criteria supplied explicitly by the
-user and writes a distinct ``.dynamic.json`` output.
+user and writes a distinct ``.dynamic.json`` output. If fitting fails after
+range selection, the current spectrum diagnostics are serialized before the
+error is re-raised.
 """
 
 from __future__ import annotations
@@ -160,13 +162,17 @@ def output_path_for(path: Path, dynamic_range: bool) -> Path:
 
 
 def process_file(path: Path, args: argparse.Namespace) -> None:
-    """Fit one contour trajectory with the requested config and write JSON."""
+    """Fit one trajectory and serialize results or failure diagnostics."""
     config = build_fit_config(args)
     output_path = output_path_for(path, args.dynamic_range)
 
     print(f"Working on file {path.stem}")
     spectrum = Spectrum(path)
-    fit = spectrum.extract_kc_from_fit(config)
+    try:
+        fit = spectrum.extract_kc_from_fit(config)
+    except ValueError:
+        spectrum.to_json(output_path)
+        raise
     print(f"kc={fit.kC}, sigma={fit.surface_tension}")
     spectrum.to_json(output_path)
 


### PR DESCRIPTION
## Description
Add modular Fourier-mode range selection to EdgeMod so spectra can either use a fixed q range or automatically select a trustworthy range consistent with q^-3 scaling.

`QMinusThreeFitRangeSelector` searches only within a user-defined q interval, evaluates contiguous integer-q windows in log space, and accepts windows that satisfy explicit slope and residual tolerances. The longest acceptable window is used for the existing physical spectrum fit. If no trustworthy q^-3 range is found, the spectrum is rejected before a bending modulus is calculated.

All scientific fitting parameters are now centralized in `SpectrumFitConfig`, which contains `lmax`, `free_sigma`, `temperature`, and the q-range selector. Fixed and dynamic fitting therefore use the same `Spectrum.extract_kc_from_fit(config)` code path.

Each successful fit returns an immutable `SpectrumFit` containing the fitted bending modulus, surface tension, actual q bounds used, full fit configuration, and range-selection diagnostics. Successful fits are retained in `Spectrum.fit_results`, allowing fixed and dynamic analyses of the same `Spectrum` to coexist and be compared without one overwriting the other. `Spectrum.kC` and `Spectrum.surface_tension` remain available as the most recent successful fit values.

Serialized spectrum output includes all retained fit results and their configs so the exact analysis settings remain available for later comparison and reporting.

The EdgeMod CLI now supports both fitting strategies. Fixed fitting remains the default. Dynamic fitting requires explicit `min_modes`, `slope_tolerance`, and `max_log_rmse` values. Fixed CLI output remains `<input>.json`; dynamic output is written to `<input>.dynamic.json`, preventing the two workflows from overwriting each other.

The root README, EdgeMod CLI guide, example usage, and affected EdgeMod docstrings have been updated to describe the config-driven API, dynamic range selection, fit-result provenance, and current `SpectrumEnsemble` behavior.

Closes #71.

## Usage Changes
The fitting API now uses `SpectrumFitConfig`:

```python
from vesmod.EdgeMod import (
    FixedFitRangeSelector,
    SpectrumFitConfig,
)

config = SpectrumFitConfig(
    lmax=500,
    free_sigma=True,
    temperature=295.0,
    range_selector=FixedFitRangeSelector(
        lower_bound=3,
        upper_bound=8,
    ),
)

fit = spectrum.extract_kc_from_fit(config)
print(fit.kC, fit.surface_tension)
```

Calling `extract_kc_from_fit()` without a config preserves the historical default fit over q = 3, 4, 5, 6, 7 with `lmax=500`, free sigma, and 295 K:

```python
fit = spectrum.extract_kc_from_fit()
```

Dynamic range selection uses the same config interface:

```python
from vesmod.EdgeMod import (
    QMinusThreeFitRangeSelector,
    SpectrumFitConfig,
)

config = SpectrumFitConfig(
    lmax=500,
    free_sigma=True,
    temperature=295.0,
    range_selector=QMinusThreeFitRangeSelector(
        lower_bound=3,
        upper_bound=20,
        min_modes=5,
        slope_tolerance=0.2,
        max_log_rmse=0.1,
    ),
)

dynamic_fit = spectrum.extract_kc_from_fit(config)
```

For `QMinusThreeFitRangeSelector`, `lower_bound` and `upper_bound` define the trusted interval in which the selector is allowed to search. `min_modes` sets the minimum accepted contiguous q-window length. `slope_tolerance` controls the allowed deviation from a -3 log-log slope, and `max_log_rmse` controls the allowed residual to the fixed q^-3 model. These acceptance criteria intentionally have no hidden defaults.

Fixed and dynamic fits can be retained and compared on the same `Spectrum`:

```python
fixed_fit = spectrum.extract_kc_from_fit(fixed_config)
dynamic_fit = spectrum.extract_kc_from_fit(dynamic_config)

print(fixed_fit.kC, fixed_fit.lower_bound, fixed_fit.upper_bound)
print(dynamic_fit.kC, dynamic_fit.lower_bound, dynamic_fit.upper_bound)
```

Both fits remain in `spectrum.fit_results` and are serialized by `spectrum.to_json(...)` with their configs and selection diagnostics.

CLI fixed fitting remains the default:

```bash
edgemod edges.npy \
  --lower-fitting-bound 3 \
  --upper-fitting-bound 8
```

Dynamic fitting is enabled with `--dynamic-range` and requires explicit acceptance criteria:

```bash
edgemod edges.npy \
  --dynamic-range \
  --lower-fitting-bound 3 \
  --upper-fitting-bound 20 \
  --min-modes 5 \
  --slope-tolerance 0.2 \
  --max-log-rmse 0.1
```

Fixed output is written to `edges.json`; dynamic output is written to `edges.dynamic.json`.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Add a modular q-range selection interface
- [x] Preserve fixed-range fitting as the default behavior
- [x] Add q^-3-based dynamic range selection within a configurable trusted q interval
- [x] Require candidate windows to contain consecutive integer q modes
- [x] Evaluate candidate windows using log-log slope and residual to a fixed q^-3 model
- [x] Prefer the longest candidate window satisfying the configured acceptance criteria
- [x] Reject spectra with no trustworthy q^-3 range before the physical fit
- [x] Require explicit dynamic-selection thresholds rather than embedding empirical defaults
- [x] Add `SpectrumFitConfig` as the single scientific fit configuration
- [x] Route fixed and dynamic fits through the same config-driven `extract_kc_from_fit()` path
- [x] Add immutable `SpectrumFit` results with fit values, q-range provenance, config, and selection diagnostics
- [x] Retain multiple successful fits on one `Spectrum`
- [x] Serialize all retained fit results and configs for fixed-vs-dynamic comparison
- [x] Add dynamic range selection to the EdgeMod CLI
- [x] Prevent dynamic CLI output from overwriting fixed CLI output
- [x] Update example usage to the config-driven API
- [x] Update root README and EdgeMod CLI documentation
- [x] Update affected EdgeMod module, class, and method docstrings
- [x] Remove stale `SpectrumEnsemble` docstring references
- [x] Add unit tests for selector validation, config validation, physical-fit integration, retained multiple fits, serialization, and CLI config construction

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] New configuration parameters are documented (Usage changes above)
- [x] Changes propagated to examples, READMEs, CLI documentation, and docstrings

## Review checklist (Reviewer)
- [ ] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] All notebooks still function correctly

## Status
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable fixed-range and dynamic q⁻³ spectrum fitting.
  - Dynamic fitting selects acceptable mode ranges using slope, size, and RMSE criteria.
  - Fit results now retain configuration, selected bounds, and diagnostic information.
  - Fixed and dynamic results can coexist without overwriting; dynamic outputs use `.dynamic.json`.
  - Added public access to fitting configuration, range-selection options, and result records.

- **Documentation**
  - Expanded CLI, Python API, workflow, output, and troubleshooting guidance for both fitting modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->