### PR TITLE
Add population QC diagnostic histograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,14 @@ This creates:
 ```text
 results/qc_standard/
 ├── sample01.npy
+├── sample01.population_histograms.png
 ├── sample02.npy
+├── sample02.population_histograms.png
 ├── vesedge_qc.json
 └── qc_summary.csv
 ```
 
-`vesedge_qc.json` records the exact QC configuration and input path. `qc_summary.csv` reports extraction failures, curvature rejections, population rejections, accepted-frame counts, and accepted fractions for each checkpoint.
+`vesedge_qc.json` records the exact QC configuration and input path. `qc_summary.csv` reports extraction failures, curvature rejections, population rejections, accepted-frame counts, and accepted fractions for each checkpoint. When population QC is enabled, each `.population_histograms.png` figure shows the fitted populations across center x, center y, and median radius.
 
 ### 3. Compare alternate QC configurations
 
@@ -210,6 +212,7 @@ After a completed QC run, `edges.qc_result` contains the configuration and resul
 | `.npz` | Reusable, QC-independent VesEdge extraction checkpoint |
 | `.gif` | Visual inspection of raw image frames with extracted contours |
 | `.npy` | Accepted contour radii for one QC configuration, ready for EdgeMod |
+| `.population_histograms.png` | Center and radius distributions grouped by the population-QC assignments |
 | `vesedge_qc.json` | QC configuration and source path for one QC batch |
 | `qc_summary.csv` | Per-video QC counts and accepted fractions for one QC batch |
 | `.json` | EdgeMod spectrum/fitting output |

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ After a completed QC run, `edges.qc_result` contains the configuration and resul
 | `vesedge_qc.json` | QC configuration and source path for one QC batch |
 | `qc_summary.csv` | Per-video QC counts and accepted fractions for one QC batch |
 | `.json` | EdgeMod spectrum/fitting output |
+| `.spectrum_diagnostic.png` | Measured spectrum, attempted fit, compensated spectrum, and fit residuals |
 
 ---
 

--- a/docs/EdgeMod_CLI_README.md
+++ b/docs/EdgeMod_CLI_README.md
@@ -12,6 +12,7 @@ EdgeMod is a command-line tool for fitting membrane bending moduli from vesicle 
 * Configurable Fourier fitting range
 * Configurable spherical harmonic summation limit
 * JSON output for downstream analysis
+* Spectrum-fit diagnostic PNG, including rejected fit attempts
 
 ---
 
@@ -45,7 +46,13 @@ This performs a fit using the default fitting parameters and writes:
 
 ```text
 sample.json
+sample.spectrum_diagnostic.png
 ```
+
+If fit validation fails, EdgeMod still writes the diagnostic PNG before
+raising the validation error. The figure shows the measured and attempted
+theoretical spectra, the selected fitting modes, the $q^4$-compensated
+spectrum, relative residuals, fitted parameters, and the rejection reason.
 
 For a VesEdge batch, the recommended input is a QC output directory:
 
@@ -264,7 +271,11 @@ EdgeMod writes:
 
 ```text
 sample.json
+sample.spectrum_diagnostic.png
 ```
+
+The JSON file is written only after a fit passes validation. The diagnostic
+PNG is written for both accepted and rejected fits.
 
 ### JSON Output
 

--- a/docs/EdgeMod_CLI_README.md
+++ b/docs/EdgeMod_CLI_README.md
@@ -20,7 +20,7 @@ Fixed fitting remains the default CLI behavior.
 * Explicit dynamic q^-3 acceptance criteria
 * Rejection of spectra with no trustworthy q^-3 regime
 * Configurable spherical harmonic summation limit
-* Spectrum-fit diagnostic PNG, including rejected fit attempts
+* Spectrum-fit diagnostic PNG for attempted physical fits, including fits rejected by validation
 * JSON output containing fit values, q bounds, configuration, and selection diagnostics
 * Separate fixed and dynamic output filenames for direct comparison
 
@@ -68,10 +68,9 @@ sample.json
 sample.spectrum_diagnostic.png
 ```
 
-If fit validation fails, EdgeMod still writes the diagnostic PNG before
-raising the validation error. The figure shows the measured and attempted
-theoretical spectra, the selected fitting modes, the $q^4$-compensated
-spectrum, relative residuals, fitted parameters, and the rejection reason.
+If physical-fit validation fails after an HSS97 fit is attempted, EdgeMod still writes the diagnostic PNG before raising the validation error. The figure shows the measured and attempted theoretical spectra, the selected fitting modes, the $q^4$-compensated spectrum, relative residuals, fitted parameters, and the rejection reason.
+
+A dynamic q-range selection rejection is different: no HSS97 fit is attempted, so there is no spectrum-fit diagnostic PNG. The rejection diagnostics are instead written to the dynamic JSON output.
 
 For a VesEdge batch, the recommended input is a QC output directory:
 
@@ -299,14 +298,16 @@ sample.json
 sample.spectrum_diagnostic.png
 ```
 
-and dynamic fitting writes:
->>>>>>> main
+and successful dynamic fitting writes:
 
 ```text
 sample.dynamic.json
+sample.dynamic.spectrum_diagnostic.png
 ```
 
 This naming allows the same contour file to be analyzed with fixed and dynamic fitting without the second CLI run overwriting the first.
+
+If dynamic q-range selection rejects the spectrum before physical fitting, `sample.dynamic.json` is still written but `sample.dynamic.spectrum_diagnostic.png` is not, because no HSS97 fit was attempted.
 
 ### JSON Output
 
@@ -415,14 +416,16 @@ edgemod sample.npy \
     --max-log-rmse 0.1
 ```
 
-After both successful commands, both files are available:
+After both successful commands, the JSON and fit-diagnostic files for both strategies are available:
 
 ```text
 sample.json
+sample.spectrum_diagnostic.png
 sample.dynamic.json
+sample.dynamic.spectrum_diagnostic.png
 ```
 
-If dynamic selection rejects the spectrum, `sample.dynamic.json` is still written with the rejection diagnostics before the CLI reports the error.
+If dynamic selection rejects the spectrum, `sample.dynamic.json` is still written with the rejection diagnostics before the CLI reports the error; there is no dynamic spectrum-fit PNG because no physical fit was attempted.
 
 ### Analyze every vesicle in one VesEdge QC result
 

--- a/docs/VesEdge_CLI_README.md
+++ b/docs/VesEdge_CLI_README.md
@@ -96,7 +96,7 @@ sample.gif
 
 When recursive input discovery is used with `--output-dir`, VesEdge preserves each input file's path relative to the selected input directory. For example, `videos/a/sample.nd2` and `videos/b/sample.nd2` produce `checkpoints/a/sample.npz` and `checkpoints/b/sample.npz` rather than colliding.
 
-The `.npz` file is the reusable extraction product. It contains successful detections, extraction failures, frame ordering, pixel-space native and analysis contours, and the extraction configuration. It contains no QC decisions.
+The `.npz` file is the reusable extraction product. It contains successful detections, extraction failures, frame ordering, pixel-space native and analysis contours, the extraction configuration, and source-video provenance when available. It contains no QC decisions.
 
 The GIF overlays the extracted full contour on the original image frames for visual inspection.
 
@@ -171,7 +171,7 @@ The command requires an output directory:
 vesedge qc ./checkpoints --output-dir ./results/qc_standard
 ```
 
-Use a **different output directory for each QC configuration**. This keeps the `.npy` data, exact QC settings, resolved checkpoint selection, and QC summary together as one reproducible analysis condition.
+Use a **different output directory for each QC configuration**. This keeps the `.npy` data, exact QC settings, resolved checkpoint selection, QC summary, and population diagnostics together as one reproducible analysis condition.
 
 ## Input Selection
 
@@ -226,6 +226,8 @@ vesedge qc ./checkpoints \
 
 Population QC compares each successful detection's vesicle center and median analysis radius across the trajectory. A two-component Gaussian-mixture model is used only when enough usable detections are available.
 
+When population QC assigns detections to a fitted population, VesEdge also saves a three-panel histogram figure showing the unscaled features used for population fitting: center x, center y, and median analysis radius. Histogram groups use the fitted population labels and include each population size in the legend. The figure is generated from all detections that participated in population fitting, including any minor population later flagged as an outlier.
+
 Disable population QC with:
 
 ```bash
@@ -242,21 +244,35 @@ For checkpoints `sample01.npz` and `sample02.npz`, the command:
 vesedge qc ./checkpoints --output-dir ./results/qc_standard
 ```
 
-creates:
+normally creates:
 
 ```text
 results/qc_standard/
 ├── sample01.npy
+├── sample01.population_histograms.png
 ├── sample02.npy
+├── sample02.population_histograms.png
 ├── vesedge_qc.json
 └── qc_summary.csv
 ```
+
+Population histogram files are present only when population QC produced population assignments for that checkpoint.
 
 ### Filtered `.npy` files
 
 Each `.npy` contains only contours accepted under the current QC configuration, with radial distances converted to microns. These files are directly consumable by EdgeMod.
 
 If a checkpoint completes QC but no frames are accepted, no `.npy` is written for that checkpoint. The outcome is still represented in `qc_summary.csv`.
+
+### Population histogram PNGs
+
+A file named `<sample>.population_histograms.png` shows the three features used by population QC:
+
+- center x-coordinate in pixels;
+- center y-coordinate in pixels;
+- median analysis-contour radius in pixels.
+
+Each panel groups detections by their fitted population label and reports the population size in the legend. These figures are diagnostic outputs for understanding why a trajectory was treated as one or two populations and for tuning population-QC thresholds.
 
 ### `vesedge_qc.json`
 
@@ -273,7 +289,7 @@ This file records:
 
 Consequently, recursive and non-recursive runs, or runs resolving to different checkpoint sets, have different provenance even if their QC thresholds are identical.
 
-If an output directory already contains incompatible provenance, VesEdge refuses to mix the results unless `--overwrite` is explicitly supplied. An incompatible overwrite first removes VesEdge-managed `.npy` outputs and QC metadata from the previous batch so orphaned filtered results cannot remain under the new provenance.
+If an output directory already contains incompatible provenance, VesEdge refuses to mix the results unless `--overwrite` is explicitly supplied. An incompatible overwrite first removes VesEdge-managed `.npy` outputs, population histogram PNGs, and QC metadata from the previous batch so orphaned results cannot remain under the new provenance.
 
 ### `qc_summary.csv`
 
@@ -319,7 +335,7 @@ edgemod ./results/qc_standard
 edgemod ./results/qc_permissive
 ```
 
-The resulting EdgeMod estimates can be reported alongside each directory's `vesedge_qc.json` and `qc_summary.csv` to show whether the scientific conclusion depends strongly on QC choices.
+The resulting EdgeMod estimates can be reported alongside each directory's `vesedge_qc.json`, `qc_summary.csv`, and population histogram figures to show whether the scientific conclusion depends strongly on QC choices.
 
 ---
 

--- a/tests/unit_tests/test_diagnostic_plotting.py
+++ b/tests/unit_tests/test_diagnostic_plotting.py
@@ -1,0 +1,41 @@
+"""Unit tests for EdgeMod fit-diagnostic plotting."""
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from vesmod.EdgeMod.diagnostic_plotting import (
+    SpectrumDiagnosticData,
+    save_spectrum_fit_diagnostic,
+)
+from vesmod.EdgeMod.spectrum_utils import HSS97
+
+
+def test_save_spectrum_fit_diagnostic_creates_png_for_rejected_fit(tmp_path):
+    """Test a diagnostic image is available when fit validation fails."""
+    modes = np.arange(2, 10)
+    measured = np.asarray(HSS97(modes, kC=25.0, sigma=2.0, lmax=30))
+    fit_result = SimpleNamespace(
+        best_values={"kC": 25.0, "sigma": 2.0},
+        params={
+            "kC": SimpleNamespace(value=25.0, stderr=30.0),
+            "sigma": SimpleNamespace(value=2.0, stderr=4.0),
+        },
+    )
+    output_path = tmp_path / "sample.spectrum_diagnostic.png"
+
+    save_spectrum_fit_diagnostic(
+        SpectrumDiagnosticData(
+            modes=modes,
+            avg_amps2=measured,
+            fit_result=fit_result,
+            lower_bound=3,
+            upper_bound=8,
+            lmax=30,
+            validation_error="poorly constrained kC",
+        ),
+        output_path,
+    )
+
+    assert output_path.is_file()
+    assert output_path.stat().st_size > 0

--- a/tests/unit_tests/test_population_plotting.py
+++ b/tests/unit_tests/test_population_plotting.py
@@ -1,0 +1,60 @@
+"""Unit tests for population-QC diagnostic plotting."""
+
+from matplotlib.axes import Axes
+import numpy as np
+import pytest
+
+from vesmod.VesEdge.models import EdgeDetection, ImageContour
+from vesmod.VesEdge.population_plotting import save_population_histograms
+
+
+def _make_assigned_edge(origin, radius, population_label):
+    """Return one edge with a completed population assignment."""
+    radii = np.full(8, radius, dtype=float)
+    edge = EdgeDetection(
+        ImageContour(origin, radii.copy()),
+        ImageContour(origin, radii.copy()),
+    )
+    edge.qc.population_label = population_label
+    edge.qc.population_probability = 1.0
+    return edge
+
+
+def test_save_population_histograms_creates_labeled_three_panel_figure(
+    tmp_path,
+    monkeypatch,
+):
+    """Test each fitted population is represented in every feature panel."""
+    detections = [
+        _make_assigned_edge((0.0, 1.0), 10.0, 0),
+        _make_assigned_edge((0.5, 1.5), 11.0, 0),
+        _make_assigned_edge((20.0, 21.0), 3.0, 1),
+    ]
+    labels = []
+    original_hist = Axes.hist
+
+    def record_hist(axis, values, *args, **kwargs):
+        labels.append(kwargs["label"])
+        return original_hist(axis, values, *args, **kwargs)
+
+    monkeypatch.setattr(Axes, "hist", record_hist)
+    output_path = tmp_path / "sample.population_histograms.png"
+
+    save_population_histograms(detections, output_path)
+
+    assert output_path.is_file()
+    assert output_path.stat().st_size > 0
+    assert labels.count("Population 0 (n=2)") == 3
+    assert labels.count("Population 1 (n=1)") == 3
+
+
+def test_save_population_histograms_requires_population_assignments(tmp_path):
+    """Test plotting before population QC fails with a clear error."""
+    radii = np.full(8, 10.0, dtype=float)
+    edge = EdgeDetection(
+        ImageContour((0.0, 0.0), radii),
+        ImageContour((0.0, 0.0), radii),
+    )
+
+    with pytest.raises(ValueError, match="Population QC must assign"):
+        save_population_histograms([edge], tmp_path / "histogram.png")

--- a/tests/unit_tests/test_population_plotting.py
+++ b/tests/unit_tests/test_population_plotting.py
@@ -4,7 +4,7 @@ from matplotlib.axes import Axes
 import numpy as np
 import pytest
 
-from vesmod.VesEdge.models import EdgeDetection, ImageContour
+from vesmod.VesEdge.models import EdgeDetection, ImageContour, QCFlag
 from vesmod.VesEdge.population_plotting import save_population_histograms
 
 
@@ -58,3 +58,18 @@ def test_save_population_histograms_requires_population_assignments(tmp_path):
 
     with pytest.raises(ValueError, match="Population QC must assign"):
         save_population_histograms([edge], tmp_path / "histogram.png")
+
+
+def test_save_population_histograms_skips_when_preceding_qc_rejects_all(tmp_path):
+    """Test zero population-eligible detections produce no figure or error."""
+    radii = np.full(8, 10.0, dtype=float)
+    edge = EdgeDetection(
+        ImageContour((0.0, 0.0), radii),
+        ImageContour((0.0, 0.0), radii),
+    )
+    edge.qc.flags.add(QCFlag.CURVATURE)
+    output_path = tmp_path / "histogram.png"
+
+    save_population_histograms([edge], output_path)
+
+    assert not output_path.exists()

--- a/tests/unit_tests/test_spectrum.py
+++ b/tests/unit_tests/test_spectrum.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # tests/test_spectrum.py
 import json
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -244,12 +245,14 @@ def test_extract_kc_from_fit_uses_mode_range_and_saves_fit_results(monkeypatch):
     spectrum.surface_tension = None
     calls = {}
 
-    def fake_fit_spectrum_to_theory_lmfit(fitting_range, lmax, free_sigma):
+    def fake_fit_spectrum_lmfit(fitting_range, lmax, free_sigma):
         calls["modes"] = fitting_range.modes.copy()
         calls["avg_amps2"] = fitting_range.avg_amps2.copy()
         calls["lmax"] = lmax
         calls["free_sigma"] = free_sigma
-        return 22.0, 3.5
+        return SimpleNamespace(
+            best_values={"kC": 22.0, "sigma": 3.5},
+        )
 
     def fake_calc_tension_from_reduced_tension(
         r0,
@@ -266,8 +269,12 @@ def test_extract_kc_from_fit_uses_mode_range_and_saves_fit_results(monkeypatch):
         return 9.9
 
     monkeypatch.setattr(
-        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
-        fake_fit_spectrum_to_theory_lmfit,
+        "vesmod.EdgeMod.spectrum.fit_spectrum_lmfit",
+        fake_fit_spectrum_lmfit,
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.validate_lmfit_result",
+        lambda result, fitting_range, free_sigma: None,
     )
     monkeypatch.setattr(
         "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",

--- a/tests/unit_tests/test_spectrum.py
+++ b/tests/unit_tests/test_spectrum.py
@@ -326,11 +326,17 @@ def test_extract_kc_from_fit_uses_default_config(monkeypatch):
         calls["modes"] = fitting_range.modes.copy()
         calls["lmax"] = lmax
         calls["free_sigma"] = free_sigma
-        return 20.0, 2.0
+        return SimpleNamespace(
+            best_values={"kC": 20.0, "sigma": 2.0},
+        )
 
     monkeypatch.setattr(
-        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        "vesmod.EdgeMod.spectrum.fit_spectrum_lmfit",
         fake_fit,
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.validate_lmfit_result",
+        lambda result, fitting_range, free_sigma: None,
     )
     monkeypatch.setattr(
         "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",

--- a/tests/unit_tests/test_spectrum_dynamic_fit.py
+++ b/tests/unit_tests/test_spectrum_dynamic_fit.py
@@ -1,5 +1,7 @@
 """Integration tests for dynamic EdgeMod spectrum fit-range selection."""
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -52,11 +54,17 @@ def test_extract_kc_from_fit_uses_dynamic_selected_range(monkeypatch):
         calls["modes"] = fitting_range.modes.copy()
         calls["lmax"] = lmax
         calls["free_sigma"] = free_sigma
-        return 20.0, 2.0
+        return SimpleNamespace(
+            best_values={"kC": 20.0, "sigma": 2.0},
+        )
 
     monkeypatch.setattr(
-        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        "vesmod.EdgeMod.spectrum.fit_spectrum_lmfit",
         fake_fit,
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.validate_lmfit_result",
+        lambda result, fitting_range, free_sigma: None,
     )
     monkeypatch.setattr(
         "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",
@@ -95,7 +103,7 @@ def test_extract_kc_from_fit_rejects_before_physical_fit(monkeypatch):
         pytest.fail("Physical spectrum fitter should not run after range rejection.")
 
     monkeypatch.setattr(
-        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        "vesmod.EdgeMod.spectrum.fit_spectrum_lmfit",
         fail_if_called,
     )
 

--- a/tests/unit_tests/test_spectrum_fit_results.py
+++ b/tests/unit_tests/test_spectrum_fit_results.py
@@ -1,5 +1,7 @@
 """Tests for preserving multiple EdgeMod fit results on one Spectrum."""
 
+from types import SimpleNamespace
+
 import numpy as np
 
 from vesmod.EdgeMod import (
@@ -45,11 +47,20 @@ def test_fixed_and_dynamic_fits_are_both_preserved(monkeypatch):
     )
 
     def fake_fit(fitting_range, lmax, free_sigma):
-        return float(fitting_range.modes[0]), 2.0
+        return SimpleNamespace(
+            best_values={
+                "kC": float(fitting_range.modes[0]),
+                "sigma": 2.0,
+            }
+        )
 
     monkeypatch.setattr(
-        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
+        "vesmod.EdgeMod.spectrum.fit_spectrum_lmfit",
         fake_fit,
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.validate_lmfit_result",
+        lambda result, fitting_range, free_sigma: None,
     )
     monkeypatch.setattr(
         "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",
@@ -108,11 +119,17 @@ def test_to_dict_serializes_all_fit_results(monkeypatch):
     )
 
     monkeypatch.setattr(
-        "vesmod.EdgeMod.spectrum.fit_spectrum_to_theory_lmfit",
-        lambda fitting_range, lmax, free_sigma: (
-            float(fitting_range.modes[0]),
-            2.0,
+        "vesmod.EdgeMod.spectrum.fit_spectrum_lmfit",
+        lambda fitting_range, lmax, free_sigma: SimpleNamespace(
+            best_values={
+                "kC": float(fitting_range.modes[0]),
+                "sigma": 2.0,
+            }
         ),
+    )
+    monkeypatch.setattr(
+        "vesmod.EdgeMod.spectrum.validate_lmfit_result",
+        lambda result, fitting_range, free_sigma: None,
     )
     monkeypatch.setattr(
         "vesmod.EdgeMod.spectrum.calc_tension_from_reduced_tension",

--- a/tests/unit_tests/test_spectrum_utils.py
+++ b/tests/unit_tests/test_spectrum_utils.py
@@ -63,6 +63,15 @@ def test_nlq_plq0_squared_requires_nonnegative_q():
         Nlq_Plq0_squared(l=2, q=-1)
 
 
+def test_nlq_plq0_squared_does_not_change_numpy_error_policy():
+    """Test local floating-point checks do not affect later calculations."""
+    original_settings = np.geterr()
+
+    Nlq_Plq0_squared(l=2, q=0)
+
+    assert np.geterr() == original_settings
+
+
 def test_hss97_returns_one_value_per_input_mode():
     """Test that HSS97 returns one theoretical spectrum value for each requested Fourier mode."""
     q = np.array([2, 3, 4])

--- a/tests/unit_tests/test_vesedge_cli.py
+++ b/tests/unit_tests/test_vesedge_cli.py
@@ -456,3 +456,63 @@ def test_run_qc_writes_summary_when_every_checkpoint_fails_to_load(
     assert "first.npz" in summary
     assert "second.npz" in summary
     assert summary.count("load_error") == 2
+
+
+def test_process_qc_file_saves_population_histogram(tmp_path, monkeypatch):
+    """Test completed population QC produces a figure beside filtered edges."""
+    observed = {}
+
+    class Detection:
+        def __init__(self):
+            self.qc = argparse.Namespace(flags=set(), passed=True)
+
+    class FakeEdges:
+        def __init__(self):
+            self.detections = [Detection()]
+            self.successful_detections = self.detections
+            self.qc_result = None
+
+        def run_qc(self, config):
+            self.qc_result = argparse.Namespace(population=object())
+
+        def save_edge_to_npy(self, path):
+            pass
+
+    edges = FakeEdges()
+    path = Path("sample.npz")
+    monkeypatch.setattr(
+        vesedge_cli.VesicleEdges,
+        "from_checkpoint",
+        lambda checkpoint_path: edges,
+    )
+    monkeypatch.setattr(
+        vesedge_cli,
+        "save_population_histograms",
+        lambda detections, output_path: observed.update(
+            detections=detections,
+            output_path=output_path,
+        ),
+    )
+    args = _qc_args(tmp_path, path)
+
+    vesedge_cli.process_qc_file(
+        path,
+        args,
+        vesedge_cli._qc_config_from_args(args),
+    )
+
+    assert observed["detections"] is edges.detections
+    assert observed["output_path"] == (
+        tmp_path / "sample.population_histograms.png"
+    )
+
+
+def test_remove_managed_qc_artifacts_removes_population_histograms(tmp_path):
+    """Test incompatible overwrite removes stale diagnostic figures."""
+    histogram = tmp_path / "nested" / "sample.population_histograms.png"
+    histogram.parent.mkdir(parents=True)
+    histogram.touch()
+
+    vesedge_cli._remove_managed_qc_artifacts(tmp_path)
+
+    assert not histogram.exists()

--- a/tests/unit_tests/test_vesedge_source_provenance.py
+++ b/tests/unit_tests/test_vesedge_source_provenance.py
@@ -1,0 +1,57 @@
+"""Regression tests for VesEdge source-video provenance in the CLI."""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from vesmod.cli import vesedge_cli
+
+
+def test_process_extract_file_sets_source_path_on_video(tmp_path, monkeypatch):
+    """Test CLI extraction preserves the original ND2 path on VesicleVideo."""
+    observed = {}
+
+    class FakeEdges:
+        def save_checkpoint(self, path):
+            observed["checkpoint"] = path
+
+    class FakeVideo:
+        def __init__(self, frames):
+            observed["frames"] = frames
+            self.source_path = None
+
+        def extract_edges(self, extractor, extraction_config):
+            observed["source_path"] = self.source_path
+            return FakeEdges()
+
+    path = tmp_path / "sample.nd2"
+    monkeypatch.setattr(
+        vesedge_cli.nd2,
+        "imread",
+        lambda input_path: np.zeros((1, 10, 10)),
+    )
+    monkeypatch.setattr(
+        vesedge_cli,
+        "load_extractor_from_module",
+        lambda import_string: object(),
+    )
+    monkeypatch.setattr(vesedge_cli, "VesicleVideo", FakeVideo)
+
+    args = argparse.Namespace(
+        input_path=path,
+        output_dir=tmp_path / "checkpoints",
+        no_gif=True,
+        overwrite=True,
+        extractor_file=None,
+        extractor="vesmod.VesEdge:extract_edge_from_frame",
+        extractor_name="extract_edge_from_frame",
+        downsample=False,
+        n_samples=120,
+        pixels_per_micron=1.0,
+    )
+
+    vesedge_cli.process_extract_file(path, args)
+
+    assert observed["source_path"] == Path(path)
+    assert observed["checkpoint"] == tmp_path / "checkpoints" / "sample.npz"

--- a/vesmod/EdgeMod/diagnostic_plotting.py
+++ b/vesmod/EdgeMod/diagnostic_plotting.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Diagnostic figures for EdgeMod spectrum fitting."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .spectrum_utils import HSS97
+
+
+@dataclass(frozen=True)
+class SpectrumDiagnosticData:
+    """Inputs required to render one spectrum-fit diagnostic."""
+
+    modes: np.ndarray
+    avg_amps2: np.ndarray
+    fit_result: Any
+    lower_bound: int
+    upper_bound: int
+    lmax: int
+    validation_error: str | None = None
+
+
+def save_spectrum_fit_diagnostic(
+    diagnostic: SpectrumDiagnosticData,
+    path,
+):
+    """Save measured spectrum, compensated spectrum, and fit residuals."""
+    plot_modes, measured = _positive_spectrum(
+        diagnostic.modes,
+        diagnostic.avg_amps2,
+    )
+    predicted = np.asarray(
+        HSS97(
+            plot_modes,
+            diagnostic.fit_result.best_values["kC"],
+            diagnostic.fit_result.best_values["sigma"],
+            diagnostic.lmax,
+        )
+    )
+    selected = (
+        (plot_modes >= diagnostic.lower_bound)
+        & (plot_modes < diagnostic.upper_bound)
+    )
+
+    figure, axes = plt.subplots(
+        1,
+        3,
+        figsize=(15, 4.5),
+        constrained_layout=True,
+    )
+    _plot_spectrum(axes[0], plot_modes, measured, predicted, selected)
+    _plot_compensated_spectrum(
+        axes[1],
+        plot_modes,
+        measured,
+        predicted,
+        selected,
+    )
+    _plot_relative_residuals(
+        axes[2],
+        plot_modes[selected],
+        measured[selected],
+        predicted[selected],
+    )
+    figure.suptitle(
+        _diagnostic_title(
+            diagnostic.fit_result,
+            diagnostic.validation_error,
+        )
+    )
+    output_path = Path(path).with_suffix(".png")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    figure.savefig(output_path, dpi=150)
+    plt.close(figure)
+
+
+def _positive_spectrum(modes, avg_amps2):
+    """Return positive modes for which the HSS97 expression is defined."""
+    mask = np.asarray(modes) >= 2
+    return np.asarray(modes)[mask], np.asarray(avg_amps2)[mask]
+
+
+def _plot_spectrum(axis, modes, measured, predicted, selected):
+    """Plot the measured and attempted theoretical spectra."""
+    axis.loglog(modes, measured, "o", color="0.55", label="Measured")
+    axis.loglog(
+        modes[selected],
+        measured[selected],
+        "o",
+        color="tab:blue",
+        label="Fitted modes",
+    )
+    axis.loglog(modes, predicted, color="tab:orange", label="Attempted fit")
+    axis.set_xlabel("Fourier mode q")
+    axis.set_ylabel(r"$\langle |u_q|^2 \rangle$")
+    axis.set_title("Fluctuation spectrum")
+    axis.legend()
+
+
+def _plot_compensated_spectrum(axis, modes, measured, predicted, selected):
+    """Plot q^4-compensated data to expose flattening or noise floors."""
+    compensation = modes**4
+    axis.semilogy(modes, compensation * measured, "o", color="0.55")
+    axis.semilogy(
+        modes[selected],
+        compensation[selected] * measured[selected],
+        "o",
+        color="tab:blue",
+    )
+    axis.semilogy(modes, compensation * predicted, color="tab:orange")
+    axis.set_xlabel("Fourier mode q")
+    axis.set_ylabel(r"$q^4\langle |u_q|^2 \rangle$")
+    axis.set_title(r"$q^4$-compensated spectrum")
+
+
+def _plot_relative_residuals(axis, modes, measured, predicted):
+    """Plot residuals relative to measured fitted-mode amplitudes."""
+    residuals = (measured - predicted) / measured
+    axis.axhline(0.0, color="black", linewidth=1)
+    axis.plot(modes, residuals, "o-", color="tab:red")
+    axis.set_xlabel("Fitted Fourier mode q")
+    axis.set_ylabel("(measured - fit) / measured")
+    axis.set_title("Fit residuals")
+
+
+def _diagnostic_title(fit_result, validation_error):
+    """Return a concise fit-result and validation summary."""
+    kc = fit_result.params["kC"]
+    sigma = fit_result.params["sigma"]
+    kc_stderr = "unknown" if kc.stderr is None else f"{kc.stderr:.3g}"
+    sigma_stderr = (
+        "unknown" if sigma.stderr is None else f"{sigma.stderr:.3g}"
+    )
+    parameters = (
+        f"kC={kc.value:.4g} ± {kc_stderr}; "
+        f"reduced sigma={sigma.value:.4g} ± {sigma_stderr}"
+    )
+    if validation_error is None:
+        return f"Spectrum fit diagnostic\n{parameters}"
+    return f"Spectrum fit diagnostic — rejected fit\n{parameters}\n{validation_error}"

--- a/vesmod/EdgeMod/spectrum.py
+++ b/vesmod/EdgeMod/spectrum.py
@@ -10,7 +10,16 @@ from types import NoneType
 import json
 import numpy as np
 from vesmod.VesEdge import VesicleEdges
-from .spectrum_utils import fit_spectrum_to_theory_lmfit, calc_tension_from_reduced_tension, MiniSpectrum
+from .diagnostic_plotting import (
+    SpectrumDiagnosticData,
+    save_spectrum_fit_diagnostic,
+)
+from .spectrum_utils import (
+    MiniSpectrum,
+    calc_tension_from_reduced_tension,
+    fit_spectrum_lmfit,
+    validate_lmfit_result,
+)
 
 
 class Spectrum:
@@ -50,6 +59,7 @@ class Spectrum:
         self.modes = self._calc_integer_modes()
         self.kC = None
         self.surface_tension = None
+        self.fit_result = None
 
     def _calc_avg_sq_amplitudes(self, r_vals_over_time: np.ndarray) -> np.ndarray:
         """Calculate the normalized Fourier transform, then square and average."""
@@ -85,8 +95,18 @@ class Spectrum:
     ) -> tuple[float, float]:
         """Fit a selected mode range to the theoretical prediction."""
         fitting_range = self.isolate_mode_range(lower_bound, upper_bound)
-        fit = fit_spectrum_to_theory_lmfit(fitting_range, lmax, free_sigma)
-        self.kC, reduced_sigma = fit
+        self.fit_result = fit_spectrum_lmfit(
+            fitting_range,
+            lmax,
+            free_sigma,
+        )
+        validate_lmfit_result(
+            self.fit_result,
+            fitting_range,
+            free_sigma,
+        )
+        self.kC = self.fit_result.best_values['kC']
+        reduced_sigma = self.fit_result.best_values['sigma']
         self.surface_tension = calc_tension_from_reduced_tension(
             self.r0,
             reduced_sigma,
@@ -94,6 +114,30 @@ class Spectrum:
             temperature,
         )
         return self.kC, self.surface_tension
+
+    def save_fit_diagnostic(
+        self,
+        path: str | Path,
+        lower_bound: int,
+        upper_bound: int,
+        lmax: int,
+        validation_error: str | None = None,
+    ) -> None:
+        """Save measured spectrum, attempted fit, and residual diagnostics."""
+        if self.fit_result is None:
+            raise ValueError("A spectrum fit must be attempted before plotting.")
+        save_spectrum_fit_diagnostic(
+            SpectrumDiagnosticData(
+                modes=self.modes,
+                avg_amps2=self.avg_amps2,
+                fit_result=self.fit_result,
+                lower_bound=lower_bound,
+                upper_bound=upper_bound,
+                lmax=lmax,
+                validation_error=validation_error,
+            ),
+            path,
+        )
 
     def _to_dict(self, include_arrays=True) -> dict:
         """Convert class attributes to a dict."""

--- a/vesmod/EdgeMod/spectrum_utils.py
+++ b/vesmod/EdgeMod/spectrum_utils.py
@@ -15,7 +15,7 @@ from lmfit import Model
 MiniSpectrum = namedtuple("MiniSpectrum", ['modes', 'avg_amps2', 'std_amps2'])
 
 
-def _validate_lmfit_result(result, fitting_group, free_sigma):
+def validate_lmfit_result(result, fitting_group, free_sigma):
     """Raise ValueError if the lmfit result is not physically or numerically reliable."""
     if not result.success:
         raise ValueError(f"Spectrum fit failed: {result.message}")
@@ -52,6 +52,18 @@ def _validate_lmfit_result(result, fitting_group, free_sigma):
         )
 
 
+def fit_spectrum_lmfit(fitting_group, lmax, free_sigma=False, weighted=False):
+    """Return the complete lmfit result for a theoretical spectrum fit."""
+    model = Model(HSS97)
+    pars = model.make_params(kC={'value': 15, 'min': 1, 'max': 500, 'vary': True}, sigma={'value': 0, 'min': -100, 'max': 1000, 'vary': free_sigma}, lmax={'value': lmax, 'vary': False})
+
+    use_weights = (weighted and np.all(np.isfinite(fitting_group.std_amps2)) and np.all(fitting_group.std_amps2 > 0))
+
+    if use_weights:
+        return model.fit(fitting_group.avg_amps2, q=fitting_group.modes, weights=(1 / fitting_group.std_amps2), params=pars, max_nfev=20000)
+    return model.fit(fitting_group.avg_amps2, q=fitting_group.modes, params=pars, max_nfev=20000)
+
+
 def fit_spectrum_to_theory_lmfit(fitting_group, lmax, free_sigma=False, weighted=False):
     """
     Fit a Mini_spectrum to the theory from Hackl, Seifert, and Sachmann 1997 \
@@ -75,17 +87,13 @@ def fit_spectrum_to_theory_lmfit(fitting_group, lmax, free_sigma=False, weighted
         The covariance matrix.
 
     """
-    model = Model(HSS97)
-    pars = model.make_params(kC={'value': 15, 'min': 1, 'max': 500, 'vary': True}, sigma={'value': 0, 'min': -100, 'max': 1000, 'vary': free_sigma}, lmax={'value': lmax, 'vary': False})
-
-    use_weights = (weighted and np.all(np.isfinite(fitting_group.std_amps2)) and np.all(fitting_group.std_amps2 > 0))
-
-    if use_weights:
-        result = model.fit(fitting_group.avg_amps2, q=fitting_group.modes, weights=(1 / fitting_group.std_amps2), params=pars, max_nfev=20000)
-    else:
-        result = model.fit(fitting_group.avg_amps2, q=fitting_group.modes, params=pars, max_nfev=20000)
-
-    _validate_lmfit_result(result, fitting_group, free_sigma)
+    result = fit_spectrum_lmfit(
+        fitting_group,
+        lmax,
+        free_sigma,
+        weighted,
+    )
+    validate_lmfit_result(result, fitting_group, free_sigma)
 
     return result.best_values['kC'], result.best_values['sigma']
 
@@ -148,9 +156,9 @@ def Nlq_Plq0_squared(l: int, q: int) -> float:
     Nlq *= (math.factorial(l - q) / math.factorial(l + q))
     sqrtNlq = np.sqrt(Nlq)
     Plq0 = lpmv(q, l, 0)
-    np.seterr(all='raise')
     try:
-        total = (sqrtNlq * Plq0)**2
+        with np.errstate(all='raise'):
+            total = (sqrtNlq * Plq0)**2
     except FloatingPointError as exc:
         raise FloatingPointError(f"FloatingPointError when l = {l}; q = {q}") from exc
     return total

--- a/vesmod/VesEdge/population_plotting.py
+++ b/vesmod/VesEdge/population_plotting.py
@@ -56,35 +56,42 @@ def save_population_histograms(
     )
 
     figure, axes = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
-    population_labels = np.unique(labels)
-    colors = plt.get_cmap("tab10").colors
-
     for feature_index, (axis, feature_name) in enumerate(
         zip(axes, feature_names, strict=True)
     ):
-        values = features[:, feature_index]
-        bin_edges = np.histogram_bin_edges(values, bins="auto")
-        for population_label in population_labels:
-            population_values = values[labels == population_label]
-            axis.hist(
-                population_values,
-                bins=bin_edges,
-                alpha=0.5,
-                color=colors[int(population_label) % len(colors)],
-                label=(
-                    f"Population {population_label} "
-                    f"(n={population_values.size})"
-                ),
-            )
-        axis.set_xlabel(feature_name)
-        axis.set_ylabel("Detections")
-        axis.legend()
+        _plot_feature_histogram(
+            axis,
+            features[:, feature_index],
+            labels,
+            feature_name,
+        )
 
     figure.suptitle("Population QC feature distributions")
     output_path = Path(path).with_suffix(".png")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     figure.savefig(output_path, dpi=150)
     plt.close(figure)
+
+
+def _plot_feature_histogram(axis, values, labels, feature_name) -> None:
+    """Plot one population-QC feature grouped by fitted population."""
+    bin_edges = np.histogram_bin_edges(values, bins="auto")
+    colors = plt.get_cmap("tab10").colors
+    for population_label in np.unique(labels):
+        population_values = values[labels == population_label]
+        axis.hist(
+            population_values,
+            bins=bin_edges,
+            alpha=0.5,
+            color=colors[int(population_label) % len(colors)],
+            label=(
+                f"Population {population_label} "
+                f"(n={population_values.size})"
+            ),
+        )
+    axis.set_xlabel(feature_name)
+    axis.set_ylabel("Detections")
+    axis.legend()
 
 
 def _population_features(

--- a/vesmod/VesEdge/population_plotting.py
+++ b/vesmod/VesEdge/population_plotting.py
@@ -19,7 +19,8 @@ def save_population_histograms(
 
     Only detections assigned a population label are shown. These are exactly
     the detections included in population fitting: extraction failures and
-    detections rejected by preceding frame-level QC are omitted.
+    detections rejected by preceding frame-level QC are omitted. If preceding
+    QC leaves no usable detections, no figure is produced.
 
     Parameters
     ----------
@@ -31,7 +32,8 @@ def save_population_histograms(
     Raises
     ------
     ValueError
-        If no detections have population assignments.
+        If usable detections exist but none has a population assignment,
+        indicating population QC has not populated the requested diagnostics.
     """
     assigned_edges = [
         result
@@ -40,6 +42,14 @@ def save_population_histograms(
         and result.qc.population_label is not None
     ]
     if not assigned_edges:
+        usable_edges = [
+            result
+            for result in detections
+            if isinstance(result, EdgeDetection)
+            and result.qc.passed
+        ]
+        if not usable_edges:
+            return
         raise ValueError(
             "Population QC must assign detections before histograms can be plotted."
         )

--- a/vesmod/VesEdge/population_plotting.py
+++ b/vesmod/VesEdge/population_plotting.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Diagnostic plots for VesEdge population quality control."""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from numpy.typing import NDArray
+
+from .models import EdgeDetection, EdgeResult
+
+
+def save_population_histograms(
+    detections: list[EdgeResult],
+    path: str | Path,
+) -> None:
+    """Save histograms of the features used for population quality control.
+
+    Only detections assigned a population label are shown. These are exactly
+    the detections included in population fitting: extraction failures and
+    detections rejected by preceding frame-level QC are omitted.
+
+    Parameters
+    ----------
+    detections : list[EdgeResult]
+        Ordered edge-extraction results after population QC has run.
+    path : str or Path
+        Destination for the PNG figure.
+
+    Raises
+    ------
+    ValueError
+        If no detections have population assignments.
+    """
+    assigned_edges = [
+        result
+        for result in detections
+        if isinstance(result, EdgeDetection)
+        and result.qc.population_label is not None
+    ]
+    if not assigned_edges:
+        raise ValueError(
+            "Population QC must assign detections before histograms can be plotted."
+        )
+
+    features = _population_features(assigned_edges)
+    labels = np.asarray(
+        [edge.qc.population_label for edge in assigned_edges],
+        dtype=int,
+    )
+    feature_names = ("Center x (pixels)", "Center y (pixels)", "Median radius (pixels)")
+
+    figure, axes = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
+    population_labels = np.unique(labels)
+    colors = plt.get_cmap("tab10").colors
+
+    for feature_index, (axis, feature_name) in enumerate(
+        zip(axes, feature_names, strict=True)
+    ):
+        values = features[:, feature_index]
+        bin_edges = np.histogram_bin_edges(values, bins="auto")
+        for population_label in population_labels:
+            population_values = values[labels == population_label]
+            axis.hist(
+                population_values,
+                bins=bin_edges,
+                alpha=0.5,
+                color=colors[int(population_label) % len(colors)],
+                label=(
+                    f"Population {population_label} "
+                    f"(n={population_values.size})"
+                ),
+            )
+        axis.set_xlabel(feature_name)
+        axis.set_ylabel("Detections")
+        axis.legend()
+
+    figure.suptitle("Population QC feature distributions")
+    output_path = Path(path).with_suffix(".png")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    figure.savefig(output_path, dpi=150)
+    plt.close(figure)
+
+
+def _population_features(
+    detections: list[EdgeDetection],
+) -> NDArray[np.float64]:
+    """Return the unscaled features used to fit population models."""
+    return np.asarray(
+        [
+            (
+                edge.full_contour.origin[0],
+                edge.full_contour.origin[1],
+                float(np.median(edge.analysis_contour.r)),
+            )
+            for edge in detections
+        ],
+        dtype=float,
+    )

--- a/vesmod/VesEdge/population_plotting.py
+++ b/vesmod/VesEdge/population_plotting.py
@@ -49,7 +49,11 @@ def save_population_histograms(
         [edge.qc.population_label for edge in assigned_edges],
         dtype=int,
     )
-    feature_names = ("Center x (pixels)", "Center y (pixels)", "Median radius (pixels)")
+    feature_names = (
+        "Center x (pixels)",
+        "Center y (pixels)",
+        "Median radius (pixels)",
+    )
 
     figure, axes = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
     population_labels = np.unique(labels)

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -75,16 +75,30 @@ def iter_npy_files(input_path: Path, recursive: bool) -> list[Path]:
 
 def process_file(path: Path, args: argparse.Namespace) -> None:
     """Fit one edge file and save its spectrum metadata to JSON."""
-    output_path = path.with_suffix(".json")
-
     print(f"Working on file {path.stem}")
     spectrum = Spectrum(path)
-    kc, sigma = spectrum.extract_kc_from_fit(
-        lower_bound=args.lower_fitting_bound,
-        upper_bound=args.upper_fitting_bound,
-        lmax=args.lmax,
-        free_sigma=not args.fixed_sigma,
-        temperature=args.temperature
+    try:
+        kc, sigma = spectrum.extract_kc_from_fit(
+            lower_bound=args.lower_fitting_bound,
+            upper_bound=args.upper_fitting_bound,
+            lmax=args.lmax,
+            free_sigma=not args.fixed_sigma,
+            temperature=args.temperature
+        )
+    except ValueError as error:
+        spectrum.save_fit_diagnostic(
+            path.with_suffix(".spectrum_diagnostic.png"),
+            args.lower_fitting_bound,
+            args.upper_fitting_bound,
+            args.lmax,
+            validation_error=str(error),
+        )
+        raise
+    spectrum.save_fit_diagnostic(
+        path.with_suffix(".spectrum_diagnostic.png"),
+        args.lower_fitting_bound,
+        args.upper_fitting_bound,
+        args.lmax,
     )
     print(f"kc={kc}, sigma={sigma}")
     spectrum.to_json(path)

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -282,7 +282,7 @@ def process_extract_file(path: Path, args: argparse.Namespace) -> None:
         pixels_per_micron=args.pixels_per_micron,
         n_angular_samples=(args.n_samples if args.downsample else None),
     )
-    video = VesicleVideo(intensities)
+    video = VesicleVideo(intensities, source_path=path)
 
     try:
         edges = video.extract_edges(extractor_func, extraction_config)
@@ -470,33 +470,43 @@ def process_qc_file(
 
 
 def _write_qc_summary(output_dir: Path, rows: list[dict]) -> None:
-    """Write one CSV row per selected checkpoint in the QC batch."""
-    if not rows:
-        return
+    """Write one CSV row per processed checkpoint."""
     summary_path = output_dir / "qc_summary.csv"
-    with summary_path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+    fieldnames = [
+        "file",
+        "frames",
+        "successful_detections",
+        "extraction_failures",
+        "curvature_rejected",
+        "population_rejected",
+        "accepted",
+        "accepted_fraction",
+        "status",
+        "error",
+    ]
+    with summary_path.open("w", newline="", encoding="utf-8") as summary_file:
+        writer = csv.DictWriter(summary_file, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
 
 
 def _run_extract(args: argparse.Namespace) -> None:
-    """Run the extraction subcommand."""
+    """Run extraction over the selected ND2 files."""
     paths = iter_input_files(args.input_path, ".nd2", args.recursive)
     if not paths:
         raise FileNotFoundError(f"No .nd2 files found in {args.input_path}")
+
     for path in paths:
         process_extract_file(path, args)
 
 
 def _run_qc(args: argparse.Namespace) -> None:
-    """Run the QC subcommand."""
+    """Run one QC configuration over the selected checkpoints."""
     paths = iter_input_files(args.input_path, ".npz", args.recursive)
     if not paths:
         raise FileNotFoundError(f"No .npz files found in {args.input_path}")
 
     qc_config = _qc_config_from_args(args)
-    args.output_dir = args.output_dir.expanduser().resolve()
     _write_qc_provenance(
         args.output_dir,
         qc_config,
@@ -505,13 +515,15 @@ def _run_qc(args: argparse.Namespace) -> None:
         paths,
         args.overwrite,
     )
-
-    rows = [process_qc_file(path, args, qc_config) for path in paths]
+    rows = [
+        process_qc_file(path, args, qc_config)
+        for path in paths
+    ]
     _write_qc_summary(args.output_dir, rows)
 
 
 def main() -> None:
-    """Run the VesEdge command-line interface."""
+    """Run the selected VesEdge subcommand."""
     args = parse_args()
     if args.command == "extract":
         _run_extract(args)

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -451,7 +451,7 @@ def process_qc_file(
     )
     if (
         edges.qc_result is not None
-        and edges.qc_result.population is not None
+        and getattr(edges.qc_result, "population", None) is not None
         and (args.overwrite or not population_figure_path.exists())
     ):
         save_population_histograms(

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -19,6 +19,7 @@ from vesmod.VesEdge import (
     VesicleEdges,
     VesicleVideo,
 )
+from vesmod.VesEdge.population_plotting import save_population_histograms
 
 
 def parse_args() -> argparse.Namespace:
@@ -322,8 +323,9 @@ def _qc_provenance(
 
 def _remove_managed_qc_artifacts(output_dir: Path) -> None:
     """Remove filtered arrays and metadata managed by a previous QC batch."""
-    for output_path in output_dir.rglob("*.npy"):
-        output_path.unlink()
+    for pattern in ("*.npy", "*.population_histograms.png"):
+        for output_path in output_dir.rglob(pattern):
+            output_path.unlink()
     for filename in ("qc_summary.csv", "vesedge_qc.json"):
         output_path = output_dir / filename
         if output_path.exists():
@@ -443,6 +445,19 @@ def process_qc_file(
         else:
             status = "no_accepted_frames"
             print(f"QC produced no accepted frames for {path.name}: {error}")
+
+    population_figure_path = output_path.with_suffix(
+        ".population_histograms.png"
+    )
+    if (
+        edges.qc_result is not None
+        and edges.qc_result.population is not None
+        and (args.overwrite or not population_figure_path.exists())
+    ):
+        save_population_histograms(
+            edges.detections,
+            population_figure_path,
+        )
 
     row = _qc_summary(path, args.input_path, edges, status, qc_error)
     if (

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -282,7 +282,8 @@ def process_extract_file(path: Path, args: argparse.Namespace) -> None:
         pixels_per_micron=args.pixels_per_micron,
         n_angular_samples=(args.n_samples if args.downsample else None),
     )
-    video = VesicleVideo(intensities, source_path=path)
+    video = VesicleVideo(intensities)
+    video.source_path = Path(path)
 
     try:
         edges = video.extract_edges(extractor_func, extraction_config)


### PR DESCRIPTION
## Description
Add diagnostic histogram output for VesEdge population QC so users can visually inspect the center/radius distributions that caused a trajectory to be treated as one or two populations.

When population QC is run, VesEdge now saves a three-panel histogram figure showing the same three features used by the population classifier: x-center, y-center, and median analysis-contour radius. Detections are grouped by their assigned population and labeled with population sizes, making it easier to inspect trajectories in which edge extraction switches between distinct objects or otherwise produces a secondary center/radius population.

The plotting code is kept separate from the QC calculation itself: population QC continues to assign labels/probabilities and make acceptance decisions, while `population_plotting.py` is responsible only for rendering those completed QC results. If earlier QC leaves no usable detections for population fitting, no histogram is produced rather than turning an otherwise valid QC outcome into a plotting failure.

This branch also incorporates the current EdgeMod spectrum-fit diagnostic behavior after merging `main`: EdgeMod retains the full `lmfit` result so successful and failed physical fits can be plotted, while preserving the config-driven fixed/dynamic q-range fitting API. Dynamic range-selection rejection is distinguished from physical-fit validation failure: selection failures persist JSON diagnostics but do not produce an HSS97 fit diagnostic because no physical fit was attempted.

Finally, VesEdge extraction now records the original `.nd2` input path on `VesicleVideo` before extraction so that provenance is propagated to `VesicleEdges` and persisted in the `.npz` checkpoint.

Closes #73.

## Usage Changes
Population QC does not require any new command-line parameters. Existing QC commands continue to work, for example:

```bash
vesedge qc checkpoints --output-dir qc_results
```

When population QC runs for a checkpoint, VesEdge may now write an additional diagnostic beside the filtered output:

```text
sample.npy
sample.population_histograms.png
```

The histogram contains three panels for x-center, y-center, and median analysis-contour radius. Each fitted population is shown separately and labeled with its population size. If population QC is disabled with `--no-population-qc`, or if no usable detections remain for population fitting, no population histogram is produced.

No changes are required for existing extraction commands. Checkpoints produced through `vesedge extract` now additionally retain the source `.nd2` path as provenance.

The merged EdgeMod CLI behavior also retains its existing diagnostic outputs:

```text
sample.json
sample.spectrum_diagnostic.png

sample.dynamic.json
sample.dynamic.spectrum_diagnostic.png
```

A dynamic q-range selection that is rejected before physical fitting writes the dynamic JSON diagnostics but does not create a spectrum-fit PNG.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Add a population-QC diagnostic plotting module
- [x] Plot the x-center, y-center, and median-radius features used by population QC
- [x] Separate detections by assigned population and report population sizes in the figure
- [x] Generate population histograms from the VesEdge QC CLI without changing population-QC decisions
- [x] Preserve relative output paths for recursive QC runs
- [x] Avoid plotting failures when earlier QC leaves no usable detections
- [x] Add regression tests for population histogram creation and empty-population behavior
- [x] Document population histogram output in the VesEdge CLI documentation
- [x] Reconcile EdgeMod diagnostic plotting with the config-driven fixed/dynamic fitting API from `main`
- [x] Preserve failed dynamic range-selection diagnostics without incorrectly generating a physical-fit plot
- [x] Preserve source `.nd2` provenance through normal `vesedge extract` CLI usage
- [x] Add regression coverage for CLI source-path propagation

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] New configuration parameters are documented (no new VesEdge QC parameters are introduced by this PR)
- [ ] Changes propagated to all notebooks

## Review checklist (Reviewer)
- [ ] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] All notebooks still function correctly

## Status
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spectrum-fit diagnostic PNGs showing measured data, fitted results, and residuals.
  * Added population-QC histogram figures for center positions and median radius by fitted population.
  * Diagnostic outputs are generated for attempted fits, including validation failures where applicable.

* **Bug Fixes**
  * Improved cleanup of stale diagnostic files during overwrite operations.
  * Preserved source-video provenance in extracted checkpoints.
  * Prevented changes to global numerical error settings.

* **Documentation**
  * Updated CLI and data-product documentation for the new outputs and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->