### PR TITLE
Skip failed spectra in recursive EdgeMod runs

### DIFF
--- a/tests/unit_tests/test_edgemod_cli.py
+++ b/tests/unit_tests/test_edgemod_cli.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from vesmod.EdgeMod import FixedFitRangeSelector, QMinusThreeFitRangeSelector
+from vesmod.cli import edgemod_cli
 from vesmod.cli.edgemod_cli import build_fit_config, output_path_for, process_file
 
 
@@ -104,3 +105,60 @@ def test_process_file_serializes_dynamic_rejection_diagnostics(tmp_path):
     assert data["fit_range_selection"]["reason"] is not None
     assert data["kC"] is None
     assert data["surface_tension"] is None
+
+
+@pytest.mark.parametrize(
+    "error", [ValueError("fit failed"), FloatingPointError("fit failed")]
+)
+def test_recursive_run_skips_failed_fit_and_continues(
+    monkeypatch, capsys, tmp_path, error
+):
+    """Test one failed spectrum does not abort a recursive batch."""
+    failed_path = tmp_path / "failed.npy"
+    successful_path = tmp_path / "successful.npy"
+    args = _args()
+    args.input_path = tmp_path
+    args.recursive = True
+    processed = []
+
+    monkeypatch.setattr(edgemod_cli, "parse_args", lambda: args)
+    monkeypatch.setattr(
+        edgemod_cli,
+        "iter_npy_files",
+        lambda input_path, recursive: [failed_path, successful_path],
+    )
+
+    def fake_process_file(path, parsed_args):
+        processed.append(path)
+        if path == failed_path:
+            raise error
+
+    monkeypatch.setattr(edgemod_cli, "process_file", fake_process_file)
+
+    edgemod_cli.main()
+
+    assert processed == [failed_path, successful_path]
+    assert f"Skipping {failed_path}: fit failed" in capsys.readouterr().err
+
+
+def test_nonrecursive_run_propagates_failed_fit(monkeypatch, tmp_path):
+    """Test a direct single-spectrum run still reports failure to the caller."""
+    failed_path = tmp_path / "failed.npy"
+    args = _args()
+    args.input_path = failed_path
+    args.recursive = False
+
+    monkeypatch.setattr(edgemod_cli, "parse_args", lambda: args)
+    monkeypatch.setattr(
+        edgemod_cli,
+        "iter_npy_files",
+        lambda input_path, recursive: [failed_path],
+    )
+    monkeypatch.setattr(
+        edgemod_cli,
+        "process_file",
+        lambda path, parsed_args: (_ for _ in ()).throw(ValueError("fit failed")),
+    )
+
+    with pytest.raises(ValueError, match="fit failed"):
+        edgemod_cli.main()

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -5,12 +5,14 @@ then delegates scientific analysis to ``Spectrum``. Fixed fitting remains the
 default; dynamic fitting uses q^-3 scaling criteria supplied explicitly by the
 user and writes a distinct ``.dynamic.json`` output. If fitting fails after
 range selection, the current spectrum diagnostics are serialized before the
-error is re-raised.
+error is re-raised. Recursive batches report that failure and continue with
+the remaining spectra.
 """
 
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from vesmod.EdgeMod import (
@@ -180,12 +182,20 @@ def process_file(path: Path, args: argparse.Namespace) -> None:
 def main() -> None:
     """Run EdgeMod over the selected file or batch of files."""
     args = parse_args()
+    # Validate shared fit settings before recursive mode begins suppressing
+    # per-spectrum failures.
+    build_fit_config(args)
     paths = iter_npy_files(args.input_path, args.recursive)
     if not paths:
         raise FileNotFoundError(f"No .npy files found in {args.input_path}")
 
     for path in paths:
-        process_file(path, args)
+        try:
+            process_file(path, args)
+        except (ValueError, FloatingPointError) as exc:
+            if not args.recursive:
+                raise
+            print(f"Skipping {path}: {exc}", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Prevent one failed EdgeMod spectrum fit from terminating an entire recursive batch.

Previously, `process_file()` serialized any available failure diagnostics and re-raised the fitting exception. Because the CLI loop did not handle that exception, the first rejected or numerically invalid spectrum stopped `edgemod --recursive` before later files could be analyzed.

Recursive runs now catch the fitting failures EdgeMod currently raises (`ValueError` and `FloatingPointError`), report the skipped input and reason on stderr, and continue with the remaining spectra. The failed spectrum is therefore excluded from the analysis without hiding which file failed or why. Any diagnostic JSON written by `process_file()` is preserved.

Direct, non-recursive runs continue to propagate the exception. Shared fitting configuration is also validated once before recursive processing begins, so an invalid CLI configuration fails immediately rather than causing every input file to be reported as an individual spectrum failure.

Closes #74.

## Usage Changes
No CLI parameters or output filenames have changed.

A recursive batch now continues after an individual fit failure:

```bash
edgemod ./results/qc_standard --recursive
```

For each failed spectrum, EdgeMod writes a message such as the following to stderr and proceeds to the next `.npy` file:

```text
Skipping /path/to/failed.npy: Spectrum fit failed: ...
```

Running EdgeMod directly on a single file retains the existing fail-fast behavior:

```bash
edgemod ./failed.npy
```

## Todos
Notable points that this PR has either accomplished or will accomplish.

- [x] Preserve available diagnostic JSON for failed fits
- [x] Skip spectra with fit-validation errors during recursive runs
- [x] Skip spectra with floating-point fitting errors during recursive runs
- [x] Report the skipped path and failure reason on stderr
- [x] Continue processing later spectra in the recursive batch
- [x] Preserve exception propagation for non-recursive runs
- [x] Validate shared fitting configuration before suppressing per-spectrum failures
- [x] Add regression tests for recursive and non-recursive behavior
- [x] Pass the complete unit test suite (185 tests)

## Pre-Review checklist (PR maker)
- [x] New functions are documented
- [x] New configuration parameters are documented (no new parameters)
- [x] Changes propagated to all notebooks (no notebook changes required)

## Review checklist (Reviewer)
- [ ] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] All notebooks still function correctly

## Status
- [ ] Ready for review
