### PR TITLE
Add experimental temporal RMS screening

### DIFF
--- a/docs/EdgeMod_CLI_README.md
+++ b/docs/EdgeMod_CLI_README.md
@@ -20,12 +20,13 @@ Stable core features:
 * Spectrum-fit diagnostic PNG for attempted physical fits
 * JSON output containing fit values, q bounds, and physical-fit configuration
 
-Experimental feature:
+Experimental features:
 
 * Optional q^-3-based dynamic range selection inside a trusted q interval
 * Explicit slope/RMSE acceptance criteria
 * Rejection when no trustworthy q^-3 regime is found
 * Separate dynamic JSON output containing experimental selection diagnostics
+* Separate temporal-RMS screening stage with batch provenance and diagnostics
 
 ---
 
@@ -160,6 +161,49 @@ Maximum allowed absolute deviation of the fitted log-log slope from -3. Must be 
 ### `--max-log-rmse`
 
 Maximum allowed natural-log-space RMSE to the fixed q^-3 model. Must be supplied explicitly and be finite/non-negative.
+
+---
+
+## Experimental Temporal-RMS Screening
+
+Temporal RMS is a separate optional stage, analogous to `vesedge qc`. It does
+not modify `Spectrum` or the core physical fit.
+
+Measure every selected trajectory without excluding any input:
+
+```bash
+edgemod experimental temporal-rms ./results/qc_standard \
+    --output-dir ./results/rms_report
+```
+
+Apply an explicitly chosen cutoff and export only accepted trajectories:
+
+```bash
+edgemod experimental temporal-rms ./results/qc_standard \
+    --output-dir ./results/rms_50nm \
+    --cutoff-nm 50
+
+edgemod ./results/rms_50nm
+```
+
+The stage removes each Fourier mode's temporal mean before combining its power,
+so persistent noncircularity does not count as motion. Input distances must be
+in microns; reported amplitudes and `--cutoff-nm` are in nanometers. The default
+mode interval is lower-inclusive and upper-exclusive, `3 <= q < 8`, and can be
+changed with `--lower-bound` and `--upper-bound`.
+
+The output directory contains:
+
+```text
+temporal_rms_qc.json
+temporal_rms_summary.csv
+temporal_rms_histogram.png
+accepted .npy trajectories, preserving relative input paths
+```
+
+As with `vesedge qc`, incompatible existing provenance requires another output
+directory or `--overwrite`. Temporal RMS is experimental and should not be
+treated as a universal physical criterion without empirical calibration.
 
 ---
 

--- a/tests/unit_tests/test_edgemod_cli.py
+++ b/tests/unit_tests/test_edgemod_cli.py
@@ -270,3 +270,42 @@ def test_run_temporal_rms_writes_vesedge_style_batch_outputs(tmp_path):
     assert (output_dir / "temporal_rms_qc.json").is_file()
     assert (output_dir / "temporal_rms_summary.csv").is_file()
     assert (output_dir / "temporal_rms_histogram.png").is_file()
+
+
+def test_temporal_rms_rejects_equal_input_and_output_without_deleting_source(
+    tmp_path,
+):
+    """Test an in-place batch is rejected before source arrays are touched."""
+    source_path = tmp_path / "source.npy"
+    np.save(source_path, np.ones((10, 120), dtype=float))
+    args = Namespace(
+        input_path=tmp_path,
+        output_dir=tmp_path,
+        recursive=False,
+        lower_bound=3,
+        upper_bound=8,
+        cutoff_nm=50.0,
+        overwrite=True,
+    )
+
+    with pytest.raises(ValueError, match="must not overlap"):
+        edgemod_cli._run_temporal_rms(args)
+
+    assert source_path.is_file()
+
+
+def test_remove_temporal_rms_artifacts_uses_validated_export_manifest(tmp_path):
+    """Test cleanup removes recorded exports while preserving unrelated arrays."""
+    exported_path = tmp_path / "accepted.npy"
+    unrelated_path = tmp_path / "unrelated.npy"
+    np.save(exported_path, np.ones((2, 2), dtype=float))
+    np.save(unrelated_path, np.ones((2, 2), dtype=float))
+    provenance = {
+        "experimental_method": "temporal_rms",
+        "exported_files": ["accepted.npy"],
+    }
+
+    edgemod_cli._remove_temporal_rms_artifacts(tmp_path, provenance)
+
+    assert not exported_path.exists()
+    assert unrelated_path.is_file()

--- a/tests/unit_tests/test_edgemod_cli.py
+++ b/tests/unit_tests/test_edgemod_cli.py
@@ -3,12 +3,14 @@
 from argparse import Namespace
 from pathlib import Path
 import json
+import sys
 
 import numpy as np
 import pytest
 
 from vesmod.EdgeMod import SpectrumFitConfig
 from vesmod.EdgeMod.experimental import QMinusThreeRangeSelector
+from vesmod.EdgeMod.experimental import TemporalRMSConfig
 from vesmod.cli import edgemod_cli
 from vesmod.cli.edgemod_cli import (
     build_dynamic_selector,
@@ -21,6 +23,7 @@ from vesmod.cli.edgemod_cli import (
 def _args(**overrides):
     """Return standard parsed CLI arguments with optional overrides."""
     values = {
+        "command": "fit",
         "dynamic_range": False,
         "lower_fitting_bound": 3,
         "upper_fitting_bound": 8,
@@ -33,6 +36,45 @@ def _args(**overrides):
     }
     values.update(overrides)
     return Namespace(**values)
+
+
+def test_parse_args_preserves_direct_fit_command(monkeypatch):
+    """Test the established command directly invokes core physical fitting."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["edgemod", "edges", "--fixed-sigma"],
+    )
+
+    args = edgemod_cli.parse_args()
+
+    assert args.command == "fit"
+    assert args.input_path == Path("edges")
+    assert args.fixed_sigma
+
+
+def test_parse_args_selects_temporal_rms_subcommand(monkeypatch, tmp_path):
+    """Test experimental screening options are scoped to their own stage."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "edgemod",
+            "experimental",
+            "temporal-rms",
+            "edges",
+            "--output-dir",
+            str(tmp_path),
+            "--cutoff-nm",
+            "50",
+        ],
+    )
+
+    args = edgemod_cli.parse_args()
+
+    assert args.command == "temporal-rms"
+    assert args.output_dir == tmp_path
+    assert args.cutoff_nm == pytest.approx(50.0)
 
 
 def test_build_fit_config_uses_fixed_bounds_by_default():
@@ -173,3 +215,58 @@ def test_nonrecursive_run_propagates_failed_fit(monkeypatch, tmp_path):
 
     with pytest.raises(ValueError, match="fit failed"):
         edgemod_cli.main()
+
+
+def test_process_temporal_rms_file_exports_only_included_input(tmp_path):
+    """Test the experimental stage writes only trajectories passing its cutoff."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    static_path = input_dir / "static.npy"
+    np.save(static_path, np.ones((10, 120), dtype=float))
+    args = Namespace(
+        input_path=input_dir,
+        output_dir=output_dir,
+        overwrite=False,
+    )
+    config = TemporalRMSConfig(cutoff_nm=50.0)
+
+    row, result = edgemod_cli.process_temporal_rms_file(
+        static_path,
+        args,
+        config,
+    )
+
+    assert result is not None
+    assert result.included is False
+    assert row["status"] == "below_cutoff"
+    assert not (output_dir / "static.npy").exists()
+
+
+def test_run_temporal_rms_writes_vesedge_style_batch_outputs(tmp_path):
+    """Test screening writes provenance, summary, histogram, and accepted arrays."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    angles = 2.0 * np.pi * np.arange(120) / 120
+    phases = 2.0 * np.pi * np.arange(20) / 20
+    radii = np.array(
+        [10.0 + 0.1 * np.cos(3.0 * angles + phase) for phase in phases]
+    )
+    np.save(input_dir / "moving.npy", radii)
+    args = Namespace(
+        input_path=input_dir,
+        output_dir=output_dir,
+        recursive=False,
+        lower_bound=3,
+        upper_bound=8,
+        cutoff_nm=50.0,
+        overwrite=False,
+    )
+
+    edgemod_cli._run_temporal_rms(args)
+
+    assert (output_dir / "moving.npy").is_file()
+    assert (output_dir / "temporal_rms_qc.json").is_file()
+    assert (output_dir / "temporal_rms_summary.csv").is_file()
+    assert (output_dir / "temporal_rms_histogram.png").is_file()

--- a/tests/unit_tests/test_experimental_temporal_rms.py
+++ b/tests/unit_tests/test_experimental_temporal_rms.py
@@ -1,0 +1,47 @@
+"""Tests for experimental absolute temporal-RMS screening."""
+
+import numpy as np
+import pytest
+
+from vesmod.EdgeMod.experimental import (
+    TemporalRMSConfig,
+    calculate_temporal_rms,
+)
+
+
+def test_temporal_rms_recovers_injected_mode():
+    """Test combined RMS retains physical units for a moving Fourier mode."""
+    angles = 2.0 * np.pi * np.arange(120) / 120
+    phases = 2.0 * np.pi * np.arange(20) / 20
+    amplitude_microns = 0.1
+    radii = np.array(
+        [10.0 + amplitude_microns * np.cos(3.0 * angles + phase) for phase in phases]
+    )
+
+    result = calculate_temporal_rms(radii)
+
+    assert result.amplitude_nm == pytest.approx(
+        1000.0 * amplitude_microns / np.sqrt(2.0)
+    )
+    assert result.included
+
+
+def test_temporal_rms_ignores_static_non_circularity():
+    """Test temporal centering removes a persistent Fourier mode."""
+    angles = 2.0 * np.pi * np.arange(120) / 120
+    radii = np.tile(10.0 + 0.2 * np.cos(3.0 * angles), (10, 1))
+
+    result = calculate_temporal_rms(
+        radii,
+        TemporalRMSConfig(cutoff_nm=50.0),
+    )
+
+    assert result.amplitude_nm == pytest.approx(0.0, abs=1e-11)
+    assert result.included is False
+
+
+@pytest.mark.parametrize("cutoff", [-1.0, np.inf, np.nan])
+def test_temporal_rms_config_rejects_invalid_cutoff(cutoff):
+    """Test cutoff values must be finite and non-negative."""
+    with pytest.raises(ValueError):
+        TemporalRMSConfig(cutoff_nm=cutoff)

--- a/tests/unit_tests/test_experimental_temporal_rms.py
+++ b/tests/unit_tests/test_experimental_temporal_rms.py
@@ -1,5 +1,7 @@
 """Tests for experimental absolute temporal-RMS screening."""
 
+import json
+
 import numpy as np
 import pytest
 
@@ -45,3 +47,21 @@ def test_temporal_rms_config_rejects_invalid_cutoff(cutoff):
     """Test cutoff values must be finite and non-negative."""
     with pytest.raises(ValueError):
         TemporalRMSConfig(cutoff_nm=cutoff)
+
+
+def test_temporal_rms_config_serializes_numpy_scalars():
+    """Test NumPy scalar configuration values serialize as JSON primitives."""
+    config = TemporalRMSConfig(
+        np.int64(3),
+        np.int64(8),
+        np.float32(1),
+    )
+
+    serialized = config.to_dict()
+
+    assert serialized == {
+        "lower_bound": 3,
+        "upper_bound": 8,
+        "cutoff_nm": 1.0,
+    }
+    assert json.loads(json.dumps(serialized)) == serialized

--- a/vesmod/EdgeMod/experimental/__init__.py
+++ b/vesmod/EdgeMod/experimental/__init__.py
@@ -5,8 +5,16 @@ interface and may change as the underlying methods are evaluated.
 """
 
 from .dynamic_range import DynamicRangeSelection, QMinusThreeRangeSelector
+from .temporal_rms import (
+    TemporalRMSConfig,
+    TemporalRMSResult,
+    calculate_temporal_rms,
+)
 
 __all__ = [
     "DynamicRangeSelection",
     "QMinusThreeRangeSelector",
+    "TemporalRMSConfig",
+    "TemporalRMSResult",
+    "calculate_temporal_rms",
 ]

--- a/vesmod/EdgeMod/experimental/temporal_rms.py
+++ b/vesmod/EdgeMod/experimental/temporal_rms.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from numbers import Integral, Real
 import math
 
@@ -49,7 +49,13 @@ class TemporalRMSConfig:
 
     def to_dict(self) -> dict:
         """Return JSON-serializable configuration values."""
-        return asdict(self)
+        return {
+            "lower_bound": int(self.lower_bound),
+            "upper_bound": int(self.upper_bound),
+            "cutoff_nm": (
+                None if self.cutoff_nm is None else float(self.cutoff_nm)
+            ),
+        }
 
 
 @dataclass(frozen=True)

--- a/vesmod/EdgeMod/experimental/temporal_rms.py
+++ b/vesmod/EdgeMod/experimental/temporal_rms.py
@@ -1,0 +1,111 @@
+"""Experimental temporal-RMS screening of vesicle contour trajectories."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from numbers import Integral, Real
+import math
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass(frozen=True)
+class TemporalRMSConfig:
+    """Configure experimental absolute temporal-RMS screening.
+
+    ``upper_bound`` is exclusive. When ``cutoff_nm`` is omitted, amplitudes are
+    measured and reported without excluding any trajectory.
+    """
+
+    lower_bound: int = 3
+    upper_bound: int = 8
+    cutoff_nm: float | None = None
+
+    def __post_init__(self) -> None:
+        """Validate experimental temporal-RMS parameters."""
+        for name, value in (
+            ("lower_bound", self.lower_bound),
+            ("upper_bound", self.upper_bound),
+        ):
+            if not isinstance(value, Integral) or isinstance(value, bool):
+                raise TypeError(f"{name} must be an integer q value.")
+        if self.lower_bound < 1:
+            raise ValueError("lower_bound must be at least 1.")
+        if self.upper_bound <= self.lower_bound:
+            raise ValueError("upper_bound must be greater than lower_bound.")
+
+        if self.cutoff_nm is None:
+            return
+        if not isinstance(self.cutoff_nm, Real) or isinstance(
+            self.cutoff_nm,
+            bool,
+        ):
+            raise TypeError("cutoff_nm must be numeric or None.")
+        if not math.isfinite(self.cutoff_nm):
+            raise ValueError("cutoff_nm must be finite.")
+        if self.cutoff_nm < 0:
+            raise ValueError("cutoff_nm must be non-negative.")
+
+    def to_dict(self) -> dict:
+        """Return JSON-serializable configuration values."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TemporalRMSResult:
+    """Record one trajectory's experimental temporal-RMS decision."""
+
+    amplitude_nm: float
+    included: bool
+    config: TemporalRMSConfig
+
+    def to_dict(self) -> dict:
+        """Return JSON-serializable amplitude, decision, and configuration."""
+        return {
+            "amplitude_nm": self.amplitude_nm,
+            "included": self.included,
+            "config": self.config.to_dict(),
+        }
+
+
+def calculate_temporal_rms(
+    radii_microns: NDArray[np.floating],
+    config: TemporalRMSConfig | None = None,
+) -> TemporalRMSResult:
+    """Calculate combined temporal RMS motion over selected Fourier modes.
+
+    Each mode's temporal mean is removed so persistent noncircularity does not
+    count as motion. The factor of two includes the conjugate negative-q modes
+    of each real-valued contour.
+    """
+    if config is None:
+        config = TemporalRMSConfig()
+    if not isinstance(config, TemporalRMSConfig):
+        raise TypeError("config must be a TemporalRMSConfig or None.")
+
+    radii = np.asarray(radii_microns)
+    if radii.ndim != 2:
+        raise ValueError("radii_microns must be a two-dimensional array.")
+    if radii.shape[0] == 0 or radii.shape[1] == 0:
+        raise ValueError("radii_microns must contain frames and angular samples.")
+    if not np.issubdtype(radii.dtype, np.number):
+        raise TypeError("radii_microns must contain numeric values.")
+    if not np.all(np.isfinite(radii)):
+        raise ValueError("radii_microns must contain only finite values.")
+
+    highest_exclusive_bound = (radii.shape[1] + 1) // 2
+    if config.upper_bound > highest_exclusive_bound:
+        raise ValueError("Requested temporal-RMS modes are not available.")
+
+    amplitudes = np.fft.fft(radii, axis=1) / radii.shape[1]
+    selected = amplitudes[:, config.lower_bound:config.upper_bound]
+    temporal_deviations = selected - np.mean(selected, axis=0)
+    mode_variances = np.mean(np.abs(temporal_deviations) ** 2, axis=0)
+    amplitude_nm = float(1000.0 * np.sqrt(2.0 * np.sum(mode_variances)))
+    included = config.cutoff_nm is None or amplitude_nm >= config.cutoff_nm
+    return TemporalRMSResult(
+        amplitude_nm=amplitude_nm,
+        included=included,
+        config=config,
+    )

--- a/vesmod/EdgeMod/experimental/temporal_rms_plotting.py
+++ b/vesmod/EdgeMod/experimental/temporal_rms_plotting.py
@@ -1,0 +1,35 @@
+"""Plot experimental temporal-RMS population diagnostics."""
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from .temporal_rms import TemporalRMSResult
+
+
+def save_temporal_rms_histogram(
+    results: Sequence[TemporalRMSResult],
+    output_path: str | Path,
+) -> None:
+    """Save a histogram of successfully measured trajectory amplitudes."""
+    if not results:
+        return
+
+    amplitudes = [result.amplitude_nm for result in results]
+    cutoff_nm = results[0].config.cutoff_nm
+    figure, axis = plt.subplots(figsize=(7, 5), constrained_layout=True)
+    axis.hist(amplitudes, bins="auto", edgecolor="black")
+    if cutoff_nm is not None:
+        axis.axvline(
+            cutoff_nm,
+            color="tab:red",
+            linestyle="--",
+            label=f"Cutoff: {cutoff_nm:g} nm",
+        )
+        axis.legend()
+    axis.set_xlabel("Absolute temporal RMS amplitude (nm)")
+    axis.set_ylabel("Number of spectra")
+    axis.set_title("Temporal contour motion")
+    figure.savefig(Path(output_path), dpi=150)
+    plt.close(figure)

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -349,13 +349,64 @@ def _temporal_rms_provenance(
         "recursive": recursive,
         "input_manifest": [str(path.resolve()) for path in paths],
         "config": config.to_dict(),
+        "exported_files": [],
     }
 
 
-def _remove_temporal_rms_artifacts(output_dir: Path) -> None:
-    """Remove files managed by a previous temporal-RMS batch."""
-    for output_path in output_dir.rglob("*.npy"):
-        output_path.unlink()
+def _reject_overlapping_temporal_rms_paths(
+    input_path: Path,
+    output_dir: Path,
+) -> None:
+    """Reject input/output layouts that could mix sources with exports."""
+    resolved_input = input_path.expanduser().resolve()
+    resolved_output = output_dir.expanduser().resolve()
+    if (
+        resolved_input == resolved_output
+        or resolved_input in resolved_output.parents
+        or resolved_output in resolved_input.parents
+    ):
+        raise ValueError(
+            "Temporal-RMS input and output paths must not overlap. "
+            "Choose an --output-dir outside the input path."
+        )
+
+
+def _remove_temporal_rms_artifacts(
+    output_dir: Path,
+    provenance: dict,
+) -> None:
+    """Remove only files recorded by a validated prior temporal-RMS batch."""
+    exported_files = provenance.get("exported_files")
+    if (
+        provenance.get("experimental_method") != "temporal_rms"
+        or not isinstance(exported_files, list)
+        or any(not isinstance(path, str) for path in exported_files)
+    ):
+        raise ValueError(
+            "Existing temporal-RMS metadata does not contain a valid export "
+            "manifest; refusing to remove files."
+        )
+
+    resolved_output = output_dir.expanduser().resolve()
+    export_paths = []
+    for exported_file in exported_files:
+        relative_path = Path(exported_file)
+        export_path = (resolved_output / relative_path).resolve()
+        if (
+            relative_path.is_absolute()
+            or relative_path.suffix != ".npy"
+            or resolved_output not in export_path.parents
+        ):
+            raise ValueError(
+                "Existing temporal-RMS metadata contains an unsafe export path; "
+                "refusing to remove files."
+            )
+        export_paths.append(export_path)
+
+    for export_path in export_paths:
+        if export_path.is_file():
+            export_path.unlink()
+
     for filename in (
         "temporal_rms_qc.json",
         "temporal_rms_summary.csv",
@@ -382,7 +433,11 @@ def _write_temporal_rms_provenance(
     )
     if provenance_path.exists():
         existing = json.loads(provenance_path.read_text(encoding="utf-8"))
-        if existing == provenance:
+        comparable_existing = (
+            dict(existing) if isinstance(existing, dict) else {}
+        )
+        comparable_existing["exported_files"] = []
+        if comparable_existing == provenance:
             return
         if not args.overwrite:
             raise ValueError(
@@ -390,7 +445,7 @@ def _write_temporal_rms_provenance(
                 "a different input selection or configuration. Choose another "
                 "--output-dir or use --overwrite."
             )
-        _remove_temporal_rms_artifacts(args.output_dir)
+        _remove_temporal_rms_artifacts(args.output_dir, existing)
 
     provenance_path.write_text(
         json.dumps(provenance, indent=2) + "\n",
@@ -441,6 +496,22 @@ def process_temporal_rms_file(
     )
 
 
+def _record_temporal_rms_exports(
+    output_dir: Path,
+    rows: list[dict],
+) -> None:
+    """Record the accepted arrays managed by this temporal-RMS batch."""
+    provenance_path = output_dir / "temporal_rms_qc.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    provenance["exported_files"] = [
+        row["file"] for row in rows if row["included"]
+    ]
+    provenance_path.write_text(
+        json.dumps(provenance, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _write_temporal_rms_summary(output_dir: Path, rows: list[dict]) -> None:
     """Write one experimental temporal-RMS summary row per input."""
     summary_path = output_dir / "temporal_rms_summary.csv"
@@ -478,6 +549,7 @@ def _run_fit(args: argparse.Namespace) -> None:
 
 def _run_temporal_rms(args: argparse.Namespace) -> None:
     """Run one experimental temporal-RMS configuration over selected inputs."""
+    _reject_overlapping_temporal_rms_paths(args.input_path, args.output_dir)
     paths = iter_npy_files(args.input_path, args.recursive)
     if not paths:
         raise FileNotFoundError(f"No .npy files found in {args.input_path}")
@@ -494,6 +566,7 @@ def _run_temporal_rms(args: argparse.Namespace) -> None:
     ]
     rows = [row for row, _ in processed]
     results = [result for _, result in processed if result is not None]
+    _record_temporal_rms_exports(args.output_dir, rows)
     _write_temporal_rms_summary(args.output_dir, rows)
     save_temporal_rms_histogram(
         results,

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -376,6 +376,10 @@ def _remove_temporal_rms_artifacts(
     provenance: dict,
 ) -> None:
     """Remove only files recorded by a validated prior temporal-RMS batch."""
+    if not isinstance(provenance, dict):
+        raise ValueError(
+            "Existing temporal-RMS metadata is invalid; refusing to remove files."
+        )
     exported_files = provenance.get("exported_files")
     if (
         provenance.get("experimental_method") != "temporal_rms"

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -1,4 +1,4 @@
-"""CLI for core EdgeMod fitting with optional experimental range selection.
+"""CLI for EdgeMod fitting and separate experimental screening stages.
 
 Core EdgeMod always performs a physical fit over fixed q bounds stored in a
 ``SpectrumFitConfig``. When ``--dynamic-range`` is requested, the CLI first
@@ -9,26 +9,63 @@ ordinary core fit configuration.
 from __future__ import annotations
 
 import argparse
+import csv
 from dataclasses import replace
 import json
 from pathlib import Path
 import sys
 
+import numpy as np
+
 from vesmod.EdgeMod import Spectrum, SpectrumFitConfig
 from vesmod.EdgeMod.experimental import (
     DynamicRangeSelection,
     QMinusThreeRangeSelector,
+    TemporalRMSConfig,
+    TemporalRMSResult,
+    calculate_temporal_rms,
+)
+from vesmod.EdgeMod.experimental.temporal_rms_plotting import (
+    save_temporal_rms_histogram,
 )
 
 
 def parse_args() -> argparse.Namespace:
-    """Parse input-selection, physical-fit, and experimental options."""
+    """Parse the core CLI or an explicitly namespaced experimental command."""
+    if len(sys.argv) > 1 and sys.argv[1] == "experimental":
+        parser = _experimental_parser()
+        return parser.parse_args(sys.argv[2:])
+
     parser = argparse.ArgumentParser(
         description=(
-            "Fit kc/sigma from one or more .npy edge files and write one JSON "
-            "output per input file."
-        )
+            "Fit membrane mechanical parameters from vesicle contour "
+            "trajectories."
+        ),
+        epilog=(
+            "Experimental analyses are available through "
+            "'edgemod experimental --help'."
+        ),
     )
+    _add_input_options(parser)
+    _add_fit_options(parser)
+    args = parser.parse_args()
+    args.command = "fit"
+    return args
+
+
+def _experimental_parser() -> argparse.ArgumentParser:
+    """Return the parser for explicitly experimental EdgeMod analyses."""
+    parser = argparse.ArgumentParser(
+        prog="edgemod experimental",
+        description="Run optional experimental EdgeMod analyses.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_temporal_rms_parser(subparsers)
+    return parser
+
+
+def _add_input_options(parser: argparse.ArgumentParser) -> None:
+    """Add input-path and recursion options shared by EdgeMod stages."""
     parser.add_argument(
         "input_path",
         type=Path,
@@ -39,6 +76,10 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Search subdirectories when input_path is a directory.",
     )
+
+
+def _add_fit_options(parser: argparse.ArgumentParser) -> None:
+    """Add options for core physical fitting."""
     parser.add_argument(
         "--lower-fitting-bound",
         type=int,
@@ -94,7 +135,49 @@ def parse_args() -> argparse.Namespace:
         default=295,
         help="Temperature in Kelvin when experiment performed. Default: 295.",
     )
-    return parser.parse_args()
+
+
+def _add_temporal_rms_parser(subparsers) -> None:
+    """Add options for experimental temporal-RMS screening."""
+    parser = subparsers.add_parser(
+        "temporal-rms",
+        help="EXPERIMENTAL: measure temporal contour motion and screen inputs.",
+    )
+    _add_input_options(parser)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help=(
+            "Directory for accepted .npy files, temporal_rms_qc.json, "
+            "temporal_rms_summary.csv, and the population histogram."
+        ),
+    )
+    parser.add_argument(
+        "--lower-bound",
+        type=int,
+        default=3,
+        help="Lowest Fourier mode included in temporal RMS. Default: 3.",
+    )
+    parser.add_argument(
+        "--upper-bound",
+        type=int,
+        default=8,
+        help="First Fourier mode excluded from temporal RMS. Default: 8.",
+    )
+    parser.add_argument(
+        "--cutoff-nm",
+        type=float,
+        help=(
+            "Minimum included temporal RMS amplitude in nm. If omitted, all "
+            "successfully measured inputs are retained."
+        ),
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite outputs from a different temporal-RMS configuration.",
+    )
 
 
 def iter_npy_files(input_path: Path, recursive: bool) -> list[Path]:
@@ -235,9 +318,147 @@ def process_file(path: Path, args: argparse.Namespace) -> None:
     _write_output(spectrum, output_path, selection)
 
 
-def main() -> None:
-    """Run EdgeMod over the selected file or batch of files."""
-    args = parse_args()
+def _relative_input_path(path: Path, input_path: Path) -> Path:
+    """Return one selected file relative to the user-selected input root."""
+    resolved_path = path.expanduser().resolve()
+    resolved_input = input_path.expanduser().resolve()
+    if resolved_path == resolved_input:
+        return Path(resolved_path.name)
+    return resolved_path.relative_to(resolved_input)
+
+
+def build_temporal_rms_config(args: argparse.Namespace) -> TemporalRMSConfig:
+    """Translate CLI options into an experimental temporal-RMS config."""
+    return TemporalRMSConfig(
+        lower_bound=args.lower_bound,
+        upper_bound=args.upper_bound,
+        cutoff_nm=args.cutoff_nm,
+    )
+
+
+def _temporal_rms_provenance(
+    config: TemporalRMSConfig,
+    input_path: Path,
+    recursive: bool,
+    paths: list[Path],
+) -> dict:
+    """Return serializable provenance for one temporal-RMS batch."""
+    return {
+        "experimental_method": "temporal_rms",
+        "input_path": str(input_path.expanduser().resolve()),
+        "recursive": recursive,
+        "input_manifest": [str(path.resolve()) for path in paths],
+        "config": config.to_dict(),
+    }
+
+
+def _remove_temporal_rms_artifacts(output_dir: Path) -> None:
+    """Remove files managed by a previous temporal-RMS batch."""
+    for output_path in output_dir.rglob("*.npy"):
+        output_path.unlink()
+    for filename in (
+        "temporal_rms_qc.json",
+        "temporal_rms_summary.csv",
+        "temporal_rms_histogram.png",
+    ):
+        output_path = output_dir / filename
+        if output_path.exists():
+            output_path.unlink()
+
+
+def _write_temporal_rms_provenance(
+    args: argparse.Namespace,
+    config: TemporalRMSConfig,
+    paths: list[Path],
+) -> None:
+    """Write provenance and reject incompatible existing output."""
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    provenance_path = args.output_dir / "temporal_rms_qc.json"
+    provenance = _temporal_rms_provenance(
+        config,
+        args.input_path,
+        args.recursive,
+        paths,
+    )
+    if provenance_path.exists():
+        existing = json.loads(provenance_path.read_text(encoding="utf-8"))
+        if existing == provenance:
+            return
+        if not args.overwrite:
+            raise ValueError(
+                "Temporal-RMS output directory already contains results from "
+                "a different input selection or configuration. Choose another "
+                "--output-dir or use --overwrite."
+            )
+        _remove_temporal_rms_artifacts(args.output_dir)
+
+    provenance_path.write_text(
+        json.dumps(provenance, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def process_temporal_rms_file(
+    path: Path,
+    args: argparse.Namespace,
+    config: TemporalRMSConfig,
+) -> tuple[dict, TemporalRMSResult | None]:
+    """Measure one trajectory, export it when included, and summarize it."""
+    relative_path = _relative_input_path(path, args.input_path)
+    output_path = args.output_dir / relative_path
+    try:
+        radii_microns = np.load(path)
+        result = calculate_temporal_rms(radii_microns, config)
+    except (OSError, TypeError, ValueError) as error:
+        return (
+            {
+                "file": str(relative_path),
+                "temporal_rms_nm": "",
+                "included": False,
+                "status": "analysis_error",
+                "error": str(error),
+            },
+            None,
+        )
+
+    status = "included" if result.included else "below_cutoff"
+    if result.included:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if args.overwrite or not output_path.exists():
+            np.save(output_path, radii_microns)
+        else:
+            print(f"Keeping existing output for {path.name}: {output_path.name}")
+
+    return (
+        {
+            "file": str(relative_path),
+            "temporal_rms_nm": result.amplitude_nm,
+            "included": result.included,
+            "status": status,
+            "error": "",
+        },
+        result,
+    )
+
+
+def _write_temporal_rms_summary(output_dir: Path, rows: list[dict]) -> None:
+    """Write one experimental temporal-RMS summary row per input."""
+    summary_path = output_dir / "temporal_rms_summary.csv"
+    fieldnames = [
+        "file",
+        "temporal_rms_nm",
+        "included",
+        "status",
+        "error",
+    ]
+    with summary_path.open("w", newline="", encoding="utf-8") as summary_file:
+        writer = csv.DictWriter(summary_file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _run_fit(args: argparse.Namespace) -> None:
+    """Run core fitting over selected contour trajectories."""
     build_fit_config(args)
     if args.dynamic_range:
         build_dynamic_selector(args)
@@ -253,6 +474,40 @@ def main() -> None:
             if not args.recursive:
                 raise
             print(f"Skipping {path}: {exc}", file=sys.stderr)
+
+
+def _run_temporal_rms(args: argparse.Namespace) -> None:
+    """Run one experimental temporal-RMS configuration over selected inputs."""
+    paths = iter_npy_files(args.input_path, args.recursive)
+    if not paths:
+        raise FileNotFoundError(f"No .npy files found in {args.input_path}")
+
+    config = build_temporal_rms_config(args)
+    _write_temporal_rms_provenance(
+        args,
+        config,
+        paths,
+    )
+    processed = [
+        process_temporal_rms_file(path, args, config)
+        for path in paths
+    ]
+    rows = [row for row, _ in processed]
+    results = [result for _, result in processed if result is not None]
+    _write_temporal_rms_summary(args.output_dir, rows)
+    save_temporal_rms_histogram(
+        results,
+        args.output_dir / "temporal_rms_histogram.png",
+    )
+
+
+def main() -> None:
+    """Run the selected EdgeMod analysis stage."""
+    args = parse_args()
+    if args.command == "fit":
+        _run_fit(args)
+    else:
+        _run_temporal_rms(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adds an experimental preprocessing stage for measuring absolute temporal RMS contour motion over selected Fourier modes. Each mode's temporal mean is removed before the amplitudes are combined, so persistent noncircular shape is not counted as fluctuation.

The feature is isolated under `vesmod.EdgeMod.experimental`; the core `Spectrum` model, serialization, and existing EdgeMod workflow remain unchanged. An optional threshold can exclude low-motion trajectories before further analysis, while retaining diagnostics for every input.

Closes #77.

## Usage Changes

The existing EdgeMod interface is unchanged:

```bash
edgemod INPUT
```

Temporal RMS QC is available through the experimental namespace:

```bash
edgemod experimental temporal-rms INPUT \
    --output-dir OUTPUT
```

To apply an empirical cutoff:

```bash
edgemod experimental temporal-rms INPUT \
    --output-dir OUTPUT \
    --cutoff-nm 50
```

Relevant options:

- `--recursive`: search input directories recursively
- `--output-dir`: required destination for QC artifacts and accepted arrays
- `--lower-bound`: first included Fourier mode (default: 3)
- `--upper-bound`: exclusive upper Fourier-mode bound (default: 8)
- `--cutoff-nm`: optional minimum absolute temporal RMS amplitude
- `--overwrite`: replace an incompatible existing QC run

If no cutoff is supplied, all successfully analyzed trajectories are exported. When a cutoff is supplied, below-threshold arrays remain in the reports but are not copied into the accepted output set.

Each run writes:

- `temporal_rms_summary.csv`
- `temporal_rms_histogram.png`
- `temporal_rms_qc.json` with configuration and provenance
- accepted `.npy` arrays, preserving their relative input paths

Input radii are interpreted in microns and reported RMS amplitudes are in nanometers.

## Todos

- [x] Add experimental temporal RMS configuration, calculation, and result types
- [x] Add a namespaced CLI consistent with the existing EdgeMod interface
- [x] Add optional cutoff-based filtering and accepted-file export
- [x] Add histogram, CSV summary, and provenance outputs
- [x] Add focused unit and CLI tests
- [x] Document the experimental workflow

## Pre-Review checklist (PR maker)

- [x] New functions are documented
- [x] New configuration parameters are documented (Usage Changes above)
- [x] Changes propagated to all notebooks (not applicable; no notebook changes required)

## Review checklist (Reviewer)

- [ ] Code is clear and maintainable
- [ ] Tests cover the intended behavior
- [ ] Documentation and CLI behavior are accurate
- [ ] Experimental functionality remains decoupled from core EdgeMod models

## Validation

- 207 tests passed
- Pylint score: 9.94/10

## Status

- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental temporal-RMS screening for trajectory data.
  * Added configurable Fourier-mode bounds and optional nanometer cutoffs.
  * Added CLI support for batch screening, accepted-array exports, provenance records, CSV summaries, and histograms.
  * Core fitting remains the default command, with experimental screening available separately.

* **Documentation**
  * Added CLI guidance covering temporal-RMS workflows, outputs, and overwrite requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->