### PR TITLE
81 radius only population qc

### DIFF
--- a/docs/VesEdge_CLI_README.md
+++ b/docs/VesEdge_CLI_README.md
@@ -224,9 +224,9 @@ vesedge qc ./checkpoints \
     --output-dir ./results/qc_standard
 ```
 
-Population QC compares each successful detection's vesicle center and median analysis radius across the trajectory. A two-component Gaussian-mixture model is used only when enough usable detections are available.
+Population QC compares each successful detection's median analysis radius across the trajectory. Absolute center coordinates are deliberately excluded, so camera panning or vesicle diffusion cannot be interpreted as separate populations. A two-component Gaussian-mixture model is used only when enough usable detections are available.
 
-When population QC assigns detections to a fitted population, VesEdge also saves a three-panel histogram figure showing the unscaled features used for population fitting: center x, center y, and median analysis radius. Histogram groups use the fitted population labels and include each population size in the legend. The figure is generated from all detections that participated in population fitting, including any minor population later flagged as an outlier.
+When population QC assigns detections to a fitted population, VesEdge also saves a histogram of the unscaled median-radius values used for population fitting. Histogram groups use the fitted population labels and include each population size in the legend. The figure is generated from all detections that participated in population fitting, including any minor population later flagged as an outlier.
 
 Disable population QC with:
 
@@ -266,13 +266,7 @@ If a checkpoint completes QC but no frames are accepted, no `.npy` is written fo
 
 ### Population histogram PNGs
 
-A file named `<sample>.population_histograms.png` shows the three features used by population QC:
-
-- center x-coordinate in pixels;
-- center y-coordinate in pixels;
-- median analysis-contour radius in pixels.
-
-Each panel groups detections by their fitted population label and reports the population size in the legend. These figures are diagnostic outputs for understanding why a trajectory was treated as one or two populations and for tuning population-QC thresholds.
+A file named `<sample>.population_histograms.png` shows the median analysis-contour radius used by population QC. Detections are grouped by their fitted population label, and the legend reports each population size. This diagnostic explains why a trajectory was treated as one or two radius populations and supports tuning the population-QC thresholds.
 
 ### `vesedge_qc.json`
 

--- a/tests/unit_tests/test_edge_filtering.py
+++ b/tests/unit_tests/test_edge_filtering.py
@@ -144,12 +144,13 @@ def test_check_edge_populations_uses_only_edges_that_pass_preceding_qc():
 
 def test_check_edge_populations_ignores_absolute_translation():
     """Test camera panning cannot create populations at constant radius."""
+    radii = np.random.default_rng(0).normal(10.0, 0.1, 20)
     edges = [
         _make_edge(
             origin=(100.0 * index, -50.0 * index),
-            radius=10.0,
+            radius=radius,
         )
-        for index in range(20)
+        for index, radius in enumerate(radii)
     ]
 
     result = check_edge_populations(

--- a/tests/unit_tests/test_edge_filtering.py
+++ b/tests/unit_tests/test_edge_filtering.py
@@ -141,6 +141,31 @@ def test_check_edge_populations_uses_only_edges_that_pass_preceding_qc():
     assert rejected_edge.qc.population_probability is None
 
 
+
+def test_check_edge_populations_ignores_absolute_translation():
+    """Test camera panning cannot create populations at constant radius."""
+    edges = [
+        _make_edge(
+            origin=(100.0 * index, -50.0 * index),
+            radius=10.0,
+        )
+        for index in range(20)
+    ]
+
+    result = check_edge_populations(
+        edges,
+        bic_threshold=0.0,
+        max_minor_fraction=0.25,
+    )
+
+    assert not result.two_populations_detected
+    assert result.population_sizes == (20,)
+    assert all(edge.qc.population_label == 0 for edge in edges)
+    assert all(
+        QCFlag.POPULATION_OUTLIER not in edge.qc.flags
+        for edge in edges
+    )
+
 def test_check_edge_populations_keeps_one_population_when_bic_gain_is_insufficient():
     """Test that one population is retained when BIC improvement is too small."""
     edges = [

--- a/tests/unit_tests/test_population_plotting.py
+++ b/tests/unit_tests/test_population_plotting.py
@@ -20,11 +20,11 @@ def _make_assigned_edge(origin, radius, population_label):
     return edge
 
 
-def test_save_population_histograms_creates_labeled_three_panel_figure(
+def test_save_population_histograms_creates_labeled_radius_figure(
     tmp_path,
     monkeypatch,
 ):
-    """Test each fitted population is represented in every feature panel."""
+    """Test each fitted population is represented in the radius histogram."""
     detections = [
         _make_assigned_edge((0.0, 1.0), 10.0, 0),
         _make_assigned_edge((0.5, 1.5), 11.0, 0),
@@ -44,8 +44,8 @@ def test_save_population_histograms_creates_labeled_three_panel_figure(
 
     assert output_path.is_file()
     assert output_path.stat().st_size > 0
-    assert labels.count("Population 0 (n=2)") == 3
-    assert labels.count("Population 1 (n=1)") == 3
+    assert labels.count("Population 0 (n=2)") == 1
+    assert labels.count("Population 1 (n=1)") == 1
 
 
 def test_save_population_histograms_requires_population_assignments(tmp_path):

--- a/vesmod/VesEdge/edge_filtering.py
+++ b/vesmod/VesEdge/edge_filtering.py
@@ -14,8 +14,11 @@ from .models import (
 )
 from .vesicle_video_utils import measure_wrapped_finite_second_difference
 
-POPULATION_FEATURE_COUNT = 3
-MIN_POPULATION_SAMPLE_COUNT = 2 * (POPULATION_FEATURE_COUNT + 1)
+POPULATION_FEATURE_COUNT = 1
+MIN_POPULATION_SAMPLE_COUNT = max(
+    8,
+    2 * (POPULATION_FEATURE_COUNT + 1),
+)
 
 
 def check_curvature(
@@ -62,12 +65,13 @@ def check_edge_populations(
     bic_threshold: float,
     max_minor_fraction: float,
 ) -> EdgePopulationResult:
-    """Identify a small anomalous center/radius population across frames.
+    """Identify a small anomalous radius population across frames.
 
     Only successful detections that passed all preceding QC checks are
-    included. Each detection is represented by its image-space center and
-    median analysis-contour radius. Features are robustly scaled before
-    fitting one- and two-component Gaussian mixture models.
+    included. Each detection is represented by its median analysis-contour
+    radius. Absolute center coordinates are excluded so camera panning and
+    vesicle diffusion cannot create populations. Radius is robustly scaled
+    before fitting one- and two-component Gaussian mixture models.
 
     Raises
     ------
@@ -146,14 +150,10 @@ def _get_usable_edges(
 def _population_features(
     usable_edges: list[EdgeDetection],
 ) -> NDArray[np.float64]:
-    """Build and validate center/radius features for population QC."""
+    """Build and validate radius-only features for population QC."""
     features = np.asarray(
         [
-            (
-                edge.full_contour.origin[0],
-                edge.full_contour.origin[1],
-                float(np.median(edge.analysis_contour.r)),
-            )
+            [float(np.median(edge.analysis_contour.r))]
             for edge in usable_edges
         ],
         dtype=float,
@@ -161,7 +161,7 @@ def _population_features(
 
     if not np.all(np.isfinite(features)):
         raise ValueError(
-            "Center and radius values used for population QC must be finite."
+            "Radius values used for population QC must be finite."
         )
 
     return features

--- a/vesmod/VesEdge/population_plotting.py
+++ b/vesmod/VesEdge/population_plotting.py
@@ -59,24 +59,16 @@ def save_population_histograms(
         [edge.qc.population_label for edge in assigned_edges],
         dtype=int,
     )
-    feature_names = (
-        "Center x (pixels)",
-        "Center y (pixels)",
+
+    figure, axis = plt.subplots(figsize=(7, 5), constrained_layout=True)
+    _plot_feature_histogram(
+        axis,
+        features[:, 0],
+        labels,
         "Median radius (pixels)",
     )
 
-    figure, axes = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
-    for feature_index, (axis, feature_name) in enumerate(
-        zip(axes, feature_names, strict=True)
-    ):
-        _plot_feature_histogram(
-            axis,
-            features[:, feature_index],
-            labels,
-            feature_name,
-        )
-
-    figure.suptitle("Population QC feature distributions")
+    figure.suptitle("Population QC radius distribution")
     output_path = Path(path).with_suffix(".png")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     figure.savefig(output_path, dpi=150)
@@ -110,11 +102,7 @@ def _population_features(
     """Return the unscaled features used to fit population models."""
     return np.asarray(
         [
-            (
-                edge.full_contour.origin[0],
-                edge.full_contour.origin[1],
-                float(np.median(edge.analysis_contour.r)),
-            )
+            [float(np.median(edge.analysis_contour.r))]
             for edge in detections
         ],
         dtype=float,


### PR DESCRIPTION
## Description

Makes VesEdge population QC invariant to camera panning and vesicle diffusion by removing absolute center coordinates from the Gaussian-mixture-model features.

Population fitting now uses only each detection's median analysis-contour radius. Vesicle center coordinates remain stored in the detection data and available for other analyses; they simply no longer determine population membership.

The existing workflow is otherwise preserved:

- one- and two-component GMMs are fitted once to the radius values;
- BIC determines whether the two-component model is sufficiently better;
- the conservative minimum of eight usable detections is unchanged;
- minor-population rejection behavior is unchanged;
- curvature QC is unchanged.

The population diagnostic is updated from three center/radius panels to a single histogram showing the radius feature actually used by the GMM.

This PR intentionally does not add a second GMM for center displacement or another temporal-continuity algorithm. Those methods answer a different question and can be considered separately if needed.

Closes #81.

## Usage Changes

There are no CLI parameter or configuration changes. Existing commands continue to work:

```bash
vesedge qc ./checkpoints \
    --population-bic-threshold 10 \
    --max-minor-population-fraction 0.25 \
    --output-dir ./results/qc_standard
```

The behavioral change is that population labels now reflect differences in radius only. The generated `<sample>.population_histograms.png` contains one median-radius histogram instead of separate center-x, center-y, and radius panels.

## Todos

- [x] Remove absolute center coordinates from population-GMM features
- [x] Preserve the existing minimum-sample and single-population fallback behavior
- [x] Preserve distinct-radius minor-population rejection
- [x] Update population diagnostic plotting
- [x] Add a regression test for large center translation at constant radius
- [x] Update VesEdge CLI documentation

## Pre-Review checklist (PR maker)

- [x] New functions are documented (no new public functions)
- [x] New configuration parameters are documented (no parameter changes)
- [x] Changes propagated to all notebooks (not applicable; no notebook changes required)

## Review checklist (Reviewer)

- [ ] New functions are documented 
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] All notebooks still function correctly

## Validation

- Modified source and test files compile successfully.
- Targeted checks confirm that extreme center translation does not create a second population.
- Targeted checks confirm that distinct radius populations are still separated and the configured minor population is rejected.
- Radius-only diagnostic plotting completes successfully.

The full pytest suite was not available in the implementation workspace and should be confirmed by repository CI.

## Status

- [x] Ready for review
