### PR TITLE
Add experimental median-radius dust QC

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Features include:
 * User-supplied edge extraction algorithms
 * Reusable `.npz` extraction checkpoints
 * Frame-level curvature quality control
+* Opt-in experimental median-radius screening for obvious wrong-object detections
 * Rerunnable QC without repeating edge extraction
 * QC provenance and batch-summary outputs
 * Optional angular downsampling
@@ -128,7 +129,18 @@ results/qc_standard/
 └── qc_summary.csv
 ```
 
-`vesedge_qc.json` records the exact QC configuration and input selection. `qc_summary.csv` reports extraction failures, curvature rejections, accepted-frame counts, and accepted fractions for each checkpoint. Curvature is currently VesEdge's only built-in frame-rejection rule.
+`vesedge_qc.json` records the exact QC configuration and input selection. `qc_summary.csv` reports extraction failures, curvature rejections, accepted-frame counts, and accepted fractions for each checkpoint. Curvature is VesEdge's stable built-in frame-rejection rule.
+
+An experimental, order-independent dust screen can be composed after curvature QC with an explicit relative radius cutoff:
+
+```bash
+vesedge qc ./checkpoints \
+    --curvature-threshold 5 \
+    --experimental-radius-deviation-threshold 0.2 \
+    --output-dir ./results/qc_radius_screen
+```
+
+This assumes the intended vesicle occupies more than half of the curvature-accepted frames. It is disabled unless the threshold is supplied. See the VesEdge CLI guide for its diagnostics and limitations.
 
 ### 3. Compare alternate QC configurations
 
@@ -260,6 +272,7 @@ Both successful physical fits remain available in `spectrum.fit_results`. Each `
 | `.npy` | Accepted contour radii for one QC configuration, ready for EdgeMod |
 | `vesedge_qc.json` | QC configuration and source path for one QC batch |
 | `qc_summary.csv` | Per-video QC counts and accepted fractions for one QC batch |
+| `.radius_deviation.json` | Experimental per-frame median-radius diagnostics and inclusion decisions |
 | `.spectrum_diagnostic.png` | Measured spectrum, attempted fit, compensated spectrum, and fit residuals |
 | `.json` | EdgeMod fixed-range spectrum/fitting output |
 | `.dynamic.json` | EdgeMod output produced when experimental dynamic selection is requested |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ An experimental, order-independent dust screen can be composed after curvature Q
 ```bash
 vesedge qc ./checkpoints \
     --curvature-threshold 5 \
-    --experimental-radius-deviation-threshold 0.2 \
+    --radius-deviation-threshold 0.2 \
     --output-dir ./results/qc_radius_screen
 ```
 

--- a/docs/VesEdge_CLI_README.md
+++ b/docs/VesEdge_CLI_README.md
@@ -19,7 +19,7 @@ QC-independent .npz checkpoints
                                                   EdgeMod
 ```
 
-This allows expensive image processing to be run once while QC settings are evaluated repeatedly and reproducibly. Curvature is currently the only built-in frame-rejection rule.
+This allows expensive image processing to be run once while QC settings are evaluated repeatedly and reproducibly. Curvature is the stable built-in frame-rejection rule. An opt-in experimental median-radius screen is also available for obvious wrong-object detections.
 
 ## Quick Start
 
@@ -215,7 +215,30 @@ vesedge qc ./checkpoints \
 
 With curvature QC disabled, every successfully extracted detection is exported. Extraction failures remain absent because they do not contain contours.
 
-VesEdge no longer performs GMM-based population QC. The removed options `--population-bic-threshold`, `--max-minor-population-fraction`, and `--no-population-qc` are invalid and produce an argument error. VesEdge does not currently attempt to identify dust-particle detections automatically; inspect extraction GIFs before downstream analysis.
+VesEdge no longer performs GMM-based population QC. The removed options `--population-bic-threshold`, `--max-minor-population-fraction`, and `--no-population-qc` are invalid and produce an argument error.
+
+## Experimental Median-Radius Dust Screen
+
+To reject detections of an object whose radius is clearly inconsistent with the intended vesicle, provide an explicit fractional cutoff:
+
+```bash
+vesedge qc ./checkpoints \
+    --curvature-threshold 5 \
+    --experimental-radius-deviation-threshold 0.2 \
+    --output-dir ./results/qc_radius_screen
+```
+
+The screen runs **after curvature QC**. For every curvature-accepted frame it calculates the contour's median radius, finds the trajectory-wide median of those frame radii, and rejects a frame when:
+
+```text
+abs(frame radius - reference radius) / reference radius > threshold
+```
+
+Thus `0.2` permits a 20% difference. No default cutoff is supplied: omitting the option disables the experiment and preserves the ordinary curvature-only workflow.
+
+This deliberately simple rule is order-independent, so dust at the beginning of a video is treated the same as dust in the middle or end. It assumes that the intended vesicle accounts for more than half of the curvature-accepted frames and that the dust radius differs materially from the vesicle radius. It is not a population model and does not attempt to distinguish two genuine vesicle states. A generous cutoff can preserve modest radius evolution, such as the approximately 6% change observed in Acquisition 8, while rejecting much larger object-switching errors.
+
+When enabled, the CLI writes `<sample>.radius_deviation.json`. It records the reference radius, each source frame's radius and relative deviation, and the final experimental inclusion decision. Inspect these diagnostics and extraction GIFs when choosing a cutoff.
 
 ## QC Outputs
 
@@ -235,6 +258,8 @@ results/qc_standard/
 └── qc_summary.csv
 ```
 
+With experimental radius screening enabled, each successful checkpoint also produces a `.radius_deviation.json` diagnostic file.
+
 ### Filtered `.npy` files
 
 Each `.npy` contains only contours accepted under the current QC configuration, with radial distances converted to microns. These files are directly consumable by EdgeMod.
@@ -251,6 +276,8 @@ This file records:
 - `curvature_threshold`;
 - whether curvature QC was enabled.
 
+When experimental screening is enabled, a separate `experimental.radius_deviation` section records its threshold. The setting is intentionally kept outside the stable `qc_config` object.
+
 Consequently, recursive and non-recursive runs, or runs resolving to different checkpoint sets, have different provenance even if their QC thresholds are identical.
 
 ### `qc_summary.csv`
@@ -261,6 +288,7 @@ The summary contains one row per selected checkpoint with:
 - successful edge detections;
 - extraction failures;
 - curvature rejections;
+- experimental radius-deviation rejections and reference radius, when enabled;
 - accepted frames;
 - accepted fraction;
 - processing status;
@@ -343,6 +371,22 @@ edges.save_edge_to_npy("sample.npy")
 ```
 
 A completed run is summarized by `edges.qc_result`; individual detections retain their curvature score and pass/fail flag through `EdgeDetection.qc`.
+
+The experimental calculation is available separately from the stable QC model:
+
+```python
+from vesmod.VesEdge.experimental import (
+    RadiusDeviationConfig,
+    screen_radius_deviations,
+)
+
+result = screen_radius_deviations(
+    edges.accepted_detections,
+    RadiusDeviationConfig(max_relative_deviation=0.2),
+)
+```
+
+`result.accepted_positions` identifies entries in `edges.accepted_detections`; `result.to_dict()` provides the complete serializable diagnostics. The experimental function does not mutate core QC flags or `edges.qc_result`.
 
 ---
 

--- a/docs/VesEdge_CLI_README.md
+++ b/docs/VesEdge_CLI_README.md
@@ -224,7 +224,7 @@ To reject detections of an object whose radius is clearly inconsistent with the 
 ```bash
 vesedge qc ./checkpoints \
     --curvature-threshold 5 \
-    --experimental-radius-deviation-threshold 0.2 \
+    --radius-deviation-threshold 0.2 \
     --output-dir ./results/qc_radius_screen
 ```
 

--- a/tests/unit_tests/test_experimental_radius_deviation.py
+++ b/tests/unit_tests/test_experimental_radius_deviation.py
@@ -1,0 +1,91 @@
+"""Tests for experimental median-radius dust screening."""
+
+import json
+
+import numpy as np
+import pytest
+
+from vesmod.VesEdge import EdgeDetection, ImageContour
+from vesmod.VesEdge.experimental import (
+    RadiusDeviationConfig,
+    screen_radius_deviations,
+)
+
+
+def _detection(frame_index: int, radius: float) -> EdgeDetection:
+    """Return a constant-radius detection for one source frame."""
+    contour = ImageContour(
+        origin=(0.0, 0.0),
+        r=np.full(12, radius, dtype=float),
+    )
+    return EdgeDetection(
+        full_contour=contour,
+        analysis_contour=contour,
+        frame_index=frame_index,
+    )
+
+
+def test_screen_rejects_dust_at_start_when_vesicle_is_majority():
+    """Test result does not depend on the wrong object occurring first."""
+    radii = [20.0, 21.0, 19.0, 100.0, 101.0, 99.0, 100.0]
+    detections = [_detection(index, radius) for index, radius in enumerate(radii)]
+
+    result = screen_radius_deviations(
+        detections,
+        RadiusDeviationConfig(0.2),
+    )
+
+    assert result.reference_radius_pixels == pytest.approx(99.0)
+    assert result.accepted_positions == (3, 4, 5, 6)
+    assert result.rejected_count == 3
+    assert [frame.frame_index for frame in result.frames if not frame.accepted] == [
+        0,
+        1,
+        2,
+    ]
+
+
+def test_screen_retains_gradual_acquisition_8_sized_radius_change():
+    """Test a roughly 6% physical trajectory change survives a 20% cutoff."""
+    radii = np.linspace(116.0, 110.0, 20)
+    detections = [_detection(index, radius) for index, radius in enumerate(radii)]
+
+    result = screen_radius_deviations(
+        detections,
+        RadiusDeviationConfig(0.2),
+    )
+
+    assert result.rejected_count == 0
+    assert result.accepted_count == len(detections)
+
+
+def test_screen_accepts_deviation_equal_to_threshold():
+    """Test only deviations strictly above the configured limit fail."""
+    detections = [
+        _detection(0, 8.0),
+        _detection(1, 10.0),
+        _detection(2, 10.0),
+    ]
+
+    result = screen_radius_deviations(
+        detections,
+        RadiusDeviationConfig(0.2),
+    )
+
+    assert result.frames[0].accepted
+
+
+def test_config_and_result_are_json_serializable_with_numpy_scalars():
+    """Test experimental diagnostics normalize NumPy scalar values."""
+    config = RadiusDeviationConfig(np.float32(0.2))
+    result = screen_radius_deviations([_detection(0, 10.0)], config)
+
+    json.dumps(result.to_dict())
+    assert isinstance(config.max_relative_deviation, float)
+
+
+@pytest.mark.parametrize("value", [-1, np.inf, np.nan])
+def test_config_rejects_invalid_thresholds(value):
+    """Test the explicit relative threshold is finite and non-negative."""
+    with pytest.raises(ValueError):
+        RadiusDeviationConfig(value)

--- a/tests/unit_tests/test_vesedge_cli.py
+++ b/tests/unit_tests/test_vesedge_cli.py
@@ -404,12 +404,62 @@ def test_process_qc_file_records_zero_accepted_frames(tmp_path, monkeypatch):
     )
     args = _qc_args(tmp_path, path)
     config = vesedge_cli._qc_config_from_args(args)
+    stale_output = tmp_path / "sample.npy"
+    np.save(stale_output, np.ones((2, 12)))
 
     row = vesedge_cli.process_qc_file(path, args, config)
 
     assert row["accepted"] == 0
     assert row["status"] == "no_accepted_frames"
     assert "no frames passed quality control" in row["error"]
+    assert not stale_output.exists()
+
+
+def test_overwrite_removes_stale_output_when_radius_screen_accepts_no_frames(
+    tmp_path,
+    monkeypatch,
+):
+    """Test an experimental all-rejection result removes an old export."""
+    detections = []
+    for frame_index, radius in enumerate([8.0, 12.0]):
+        contour = ImageContour(
+            origin=(0.0, 0.0),
+            r=np.full(12, radius),
+        )
+        detections.append(
+            EdgeDetection(
+                full_contour=contour,
+                analysis_contour=contour,
+                frame_index=frame_index,
+            )
+        )
+    edges = VesicleEdges(
+        extraction_config=EdgeExtractionConfig(
+            pixels_per_micron=1.0,
+            n_angular_samples=12,
+        ),
+        detections=detections,
+    )
+    monkeypatch.setattr(
+        vesedge_cli.VesicleEdges,
+        "from_checkpoint",
+        lambda checkpoint_path: edges,
+    )
+    path = Path("sample.npz")
+    args = _qc_args(tmp_path, path)
+    stale_output = tmp_path / "sample.npy"
+    np.save(stale_output, np.ones((2, 12)))
+
+    row = vesedge_cli.process_qc_file(
+        path,
+        args,
+        EdgeQCConfig(5.0, enable_curvature_qc=False),
+        vesedge_cli.RadiusDeviationConfig(0.1),
+    )
+
+    assert row["status"] == "no_accepted_frames"
+    assert row["accepted"] == 0
+    assert not stale_output.exists()
 
 
 def test_process_qc_file_returns_load_error_summary(tmp_path, monkeypatch):

--- a/tests/unit_tests/test_vesedge_cli.py
+++ b/tests/unit_tests/test_vesedge_cli.py
@@ -88,7 +88,7 @@ def test_parse_args_selects_qc_subcommand(monkeypatch, tmp_path):
     assert args.input_path == Path("checkpoints")
     assert args.output_dir == tmp_path
     assert args.no_curvature_qc
-    assert args.experimental_radius_deviation_threshold is None
+    assert args.radius_deviation_threshold is None
 
 
 def test_parse_args_accepts_experimental_radius_screen(monkeypatch, tmp_path):
@@ -102,7 +102,7 @@ def test_parse_args_accepts_experimental_radius_screen(monkeypatch, tmp_path):
             "checkpoints",
             "--output-dir",
             str(tmp_path),
-            "--experimental-radius-deviation-threshold",
+            "--radius-deviation-threshold",
             "0.2",
         ],
     )

--- a/tests/unit_tests/test_vesedge_cli.py
+++ b/tests/unit_tests/test_vesedge_cli.py
@@ -8,7 +8,13 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from vesmod.VesEdge import EdgeQCConfig
+from vesmod.VesEdge import (
+    EdgeDetection,
+    EdgeExtractionConfig,
+    EdgeQCConfig,
+    ImageContour,
+    VesicleEdges,
+)
 from vesmod.cli import vesedge_cli
 
 
@@ -82,6 +88,30 @@ def test_parse_args_selects_qc_subcommand(monkeypatch, tmp_path):
     assert args.input_path == Path("checkpoints")
     assert args.output_dir == tmp_path
     assert args.no_curvature_qc
+    assert args.experimental_radius_deviation_threshold is None
+
+
+def test_parse_args_accepts_experimental_radius_screen(monkeypatch, tmp_path):
+    """Test experimental screening requires an explicit QC-stage option."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vesedge",
+            "qc",
+            "checkpoints",
+            "--output-dir",
+            str(tmp_path),
+            "--experimental-radius-deviation-threshold",
+            "0.2",
+        ],
+    )
+
+    args = vesedge_cli.parse_args()
+
+    config = vesedge_cli._radius_deviation_config_from_args(args)
+    assert config is not None
+    assert config.max_relative_deviation == pytest.approx(0.2)
 
 
 @pytest.mark.parametrize(
@@ -252,6 +282,64 @@ def test_process_qc_file_runs_qc_and_saves_filtered_output(tmp_path, monkeypatch
     assert row["status"] == "ok"
 
 
+def test_process_qc_file_applies_experimental_screen_after_curvature(
+    tmp_path,
+    monkeypatch,
+):
+    """Test experimental rejection changes export without mutating core QC."""
+    radii = [20.0, 21.0, 100.0, 101.0, 99.0]
+    detections = []
+    for frame_index, radius in enumerate(radii):
+        contour = ImageContour(
+            origin=(0.0, 0.0),
+            r=np.full(12, radius),
+        )
+        detections.append(
+            EdgeDetection(
+                full_contour=contour,
+                analysis_contour=contour,
+                frame_index=frame_index,
+            )
+        )
+    edges = VesicleEdges(
+        extraction_config=EdgeExtractionConfig(
+            pixels_per_micron=10.0,
+            n_angular_samples=12,
+        ),
+        detections=detections,
+    )
+    monkeypatch.setattr(
+        vesedge_cli.VesicleEdges,
+        "from_checkpoint",
+        lambda checkpoint_path: edges,
+    )
+    path = Path("sample.npz")
+    args = _qc_args(tmp_path, path)
+
+    row = vesedge_cli.process_qc_file(
+        path,
+        args,
+        EdgeQCConfig(5.0, enable_curvature_qc=False),
+        vesedge_cli.RadiusDeviationConfig(0.2),
+    )
+
+    exported = np.load(tmp_path / "sample.npy")
+    diagnostics = json.loads(
+        (tmp_path / "sample.radius_deviation.json").read_text()
+    )
+    assert exported.shape == (3, 12)
+    assert np.median(exported, axis=1) == pytest.approx([10.0, 10.1, 9.9])
+    assert row["radius_deviation_rejected"] == 2
+    assert row["accepted"] == 3
+    assert all(detection.qc.passed for detection in edges.detections)
+    assert diagnostics["rejected_count"] == 2
+    assert [
+        frame["frame_index"]
+        for frame in diagnostics["frames"]
+        if not frame["accepted"]
+    ] == [0, 1]
+
+
 def test_process_qc_file_preserves_relative_output_path(tmp_path, monkeypatch):
     """Test recursive QC outputs preserve checkpoint subdirectories."""
     observed = {}
@@ -343,6 +431,8 @@ def test_process_qc_file_returns_load_error_summary(tmp_path, monkeypatch):
         "successful_detections": 0,
         "extraction_failures": 0,
         "curvature_rejected": 0,
+        "radius_deviation_rejected": 0,
+        "radius_reference_pixels": "",
         "accepted": 0,
         "accepted_fraction": 0.0,
         "status": "load_error",
@@ -395,6 +485,28 @@ def test_write_qc_provenance_records_manifest_and_recursive_setting(tmp_path):
     assert data["recursive"] is True
     assert data["checkpoint_manifest"] == [str(first.resolve()), str(second.resolve())]
     assert data["qc_config"]["curvature_threshold"] == 5.0
+
+
+def test_qc_provenance_separates_experimental_radius_configuration(tmp_path):
+    """Test the opt-in screen does not become stable EdgeQCConfig state."""
+    checkpoint = tmp_path / "sample.npz"
+    radius_config = vesedge_cli.RadiusDeviationConfig(0.2)
+
+    vesedge_cli._write_qc_provenance(
+        tmp_path / "qc",
+        EdgeQCConfig(5.0),
+        checkpoint,
+        False,
+        [checkpoint],
+        overwrite=False,
+        radius_config=radius_config,
+    )
+
+    data = json.loads((tmp_path / "qc" / "vesedge_qc.json").read_text())
+    assert "max_relative_deviation" not in data["qc_config"]
+    assert data["experimental"]["radius_deviation"] == {
+        "max_relative_deviation": 0.2,
+    }
 
 
 def test_overwrite_incompatible_provenance_removes_stale_outputs(tmp_path):
@@ -481,4 +593,3 @@ def test_run_qc_writes_summary_when_every_checkpoint_fails_to_load(
     assert "first.npz" in summary
     assert "second.npz" in summary
     assert summary.count("load_error") == 2
-

--- a/vesmod/VesEdge/experimental/__init__.py
+++ b/vesmod/VesEdge/experimental/__init__.py
@@ -1,0 +1,15 @@
+"""Experimental VesEdge analyses composed around the stable QC workflow."""
+
+from .radius_deviation import (
+    RadiusDeviationConfig,
+    RadiusDeviationFrame,
+    RadiusDeviationResult,
+    screen_radius_deviations,
+)
+
+__all__ = [
+    "RadiusDeviationConfig",
+    "RadiusDeviationFrame",
+    "RadiusDeviationResult",
+    "screen_radius_deviations",
+]

--- a/vesmod/VesEdge/experimental/radius_deviation.py
+++ b/vesmod/VesEdge/experimental/radius_deviation.py
@@ -1,0 +1,150 @@
+"""Experimental median-radius screen for obvious wrong-object detections."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from numbers import Real
+from typing import Sequence
+
+import numpy as np
+
+from ..models import EdgeDetection
+
+
+@dataclass(frozen=True)
+class RadiusDeviationConfig:
+    """Configure the experimental trajectory-level radius screen.
+
+    Parameters
+    ----------
+    max_relative_deviation : float
+        Largest accepted fractional difference between a detection's median
+        radius and the trajectory-wide median radius. For example, ``0.2``
+        permits a 20% difference.
+    """
+
+    max_relative_deviation: float
+
+    def __post_init__(self) -> None:
+        """Validate and normalize the experimental threshold."""
+        value = self.max_relative_deviation
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise TypeError("max_relative_deviation must be a real number.")
+        value = float(value)
+        if not np.isfinite(value):
+            raise ValueError("max_relative_deviation must be finite.")
+        if value < 0:
+            raise ValueError("max_relative_deviation must be non-negative.")
+        object.__setattr__(self, "max_relative_deviation", value)
+
+    def to_dict(self) -> dict[str, float]:
+        """Return JSON-serializable configuration values."""
+        return {"max_relative_deviation": float(self.max_relative_deviation)}
+
+
+@dataclass(frozen=True)
+class RadiusDeviationFrame:
+    """Experimental radius-screen result for one curvature-accepted frame."""
+
+    frame_index: int
+    median_radius_pixels: float
+    relative_deviation: float
+    accepted: bool
+
+    def to_dict(self) -> dict:
+        """Return JSON-serializable frame diagnostics."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RadiusDeviationResult:
+    """Aggregate result of the experimental median-radius screen."""
+
+    config: RadiusDeviationConfig
+    reference_radius_pixels: float
+    frames: tuple[RadiusDeviationFrame, ...]
+
+    @property
+    def accepted_positions(self) -> tuple[int, ...]:
+        """Return positions accepted within the screened detection sequence."""
+        return tuple(
+            position
+            for position, frame in enumerate(self.frames)
+            if frame.accepted
+        )
+
+    @property
+    def rejected_count(self) -> int:
+        """Return the number of detections rejected by the screen."""
+        return sum(not frame.accepted for frame in self.frames)
+
+    @property
+    def accepted_count(self) -> int:
+        """Return the number of detections accepted by the screen."""
+        return len(self.frames) - self.rejected_count
+
+    def to_dict(self) -> dict:
+        """Return complete JSON-serializable diagnostics."""
+        return {
+            "method": "median_radius_deviation",
+            "config": self.config.to_dict(),
+            "reference_radius_pixels": float(self.reference_radius_pixels),
+            "accepted_count": self.accepted_count,
+            "rejected_count": self.rejected_count,
+            "frames": [frame.to_dict() for frame in self.frames],
+        }
+
+
+def screen_radius_deviations(
+    detections: Sequence[EdgeDetection],
+    config: RadiusDeviationConfig,
+) -> RadiusDeviationResult:
+    """Screen detections against their trajectory-wide median radius.
+
+    The caller controls which detections are eligible. The VesEdge CLI passes
+    only detections that have already passed stable curvature QC, keeping this
+    experimental operation separate from the core QC state.
+
+    Raises
+    ------
+    ValueError
+        If no detections are supplied or any median radius is non-positive or
+        non-finite.
+    """
+    if not detections:
+        raise ValueError("Radius-deviation screening requires detections.")
+
+    radii = np.asarray(
+        [np.median(detection.analysis_contour.r) for detection in detections],
+        dtype=float,
+    )
+    if not np.all(np.isfinite(radii)) or np.any(radii <= 0):
+        raise ValueError(
+            "Radius-deviation screening requires positive, finite radii."
+        )
+
+    reference = float(np.median(radii))
+    deviations = np.abs(radii - reference) / reference
+    frames = tuple(
+        RadiusDeviationFrame(
+            frame_index=(
+                position
+                if detection.frame_index is None
+                else int(detection.frame_index)
+            ),
+            median_radius_pixels=float(radius),
+            relative_deviation=float(deviation),
+            accepted=bool(deviation <= config.max_relative_deviation),
+        )
+        for position, (detection, radius, deviation) in enumerate(zip(
+            detections,
+            radii,
+            deviations,
+            strict=True,
+        ))
+    )
+    return RadiusDeviationResult(
+        config=config,
+        reference_radius_pixels=reference,
+        frames=frames,
+    )

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -483,6 +483,9 @@ def process_qc_file(
             qc_error = str(error)
             print(f"Experimental QC failed for {path.name}: {error}")
 
+    if status == "no_accepted_frames" and args.overwrite and output_exists:
+        output_path.unlink()
+
     row = _qc_summary(
         path,
         args.input_path,

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -11,6 +11,7 @@ from dataclasses import asdict
 from pathlib import Path
 
 import nd2
+import numpy as np
 
 from vesmod.VesEdge import (
     EdgeExtractionConfig,
@@ -18,6 +19,11 @@ from vesmod.VesEdge import (
     QCFlag,
     VesicleEdges,
     VesicleVideo,
+)
+from vesmod.VesEdge.experimental import (
+    RadiusDeviationConfig,
+    RadiusDeviationResult,
+    screen_radius_deviations,
 )
 
 
@@ -151,6 +157,16 @@ def _add_qc_parser(subparsers) -> None:
         help="Disable frame-level curvature QC.",
     )
     parser.add_argument(
+        "--experimental-radius-deviation-threshold",
+        type=float,
+        default=None,
+        help=(
+            "After curvature QC, reject detections whose median radius differs "
+            "from the trajectory-wide median by more than this fraction. For "
+            "example, 0.2 permits 20%% deviation. Disabled by default."
+        ),
+    )
+    parser.add_argument(
         "--overwrite",
         action="store_true",
         help="Overwrite existing filtered .npy outputs and QC provenance.",
@@ -280,19 +296,39 @@ def _qc_config_from_args(args: argparse.Namespace) -> EdgeQCConfig:
     )
 
 
+def _radius_deviation_config_from_args(
+    args: argparse.Namespace,
+) -> RadiusDeviationConfig | None:
+    """Build the optional experimental radius-screen configuration."""
+    threshold = getattr(
+        args,
+        "experimental_radius_deviation_threshold",
+        None,
+    )
+    if threshold is None:
+        return None
+    return RadiusDeviationConfig(max_relative_deviation=threshold)
+
+
 def _qc_provenance(
     qc_config: EdgeQCConfig,
     input_path: Path,
     recursive: bool,
     paths: list[Path],
+    radius_config: RadiusDeviationConfig | None = None,
 ) -> dict:
     """Return serializable provenance for one resolved QC batch."""
-    return {
+    provenance = {
         "input_path": str(input_path.expanduser().resolve()),
         "recursive": recursive,
         "checkpoint_manifest": [str(path.resolve()) for path in paths],
         "qc_config": asdict(qc_config),
     }
+    if radius_config is not None:
+        provenance["experimental"] = {
+            "radius_deviation": radius_config.to_dict(),
+        }
+    return provenance
 
 
 def _remove_managed_qc_artifacts(output_dir: Path) -> None:
@@ -303,6 +339,8 @@ def _remove_managed_qc_artifacts(output_dir: Path) -> None:
         output_path = output_dir / filename
         if output_path.exists():
             output_path.unlink()
+    for output_path in output_dir.rglob("*.radius_deviation.json"):
+        output_path.unlink()
 
 
 def _write_qc_provenance(
@@ -312,11 +350,18 @@ def _write_qc_provenance(
     recursive: bool,
     paths: list[Path],
     overwrite: bool,
+    radius_config: RadiusDeviationConfig | None = None,
 ) -> None:
     """Write QC provenance and reject incompatible existing provenance."""
     output_dir.mkdir(parents=True, exist_ok=True)
     provenance_path = output_dir / "vesedge_qc.json"
-    provenance = _qc_provenance(qc_config, input_path, recursive, paths)
+    provenance = _qc_provenance(
+        qc_config,
+        input_path,
+        recursive,
+        paths,
+        radius_config,
+    )
 
     if provenance_path.exists():
         existing = json.loads(provenance_path.read_text(encoding="utf-8"))
@@ -342,6 +387,7 @@ def _qc_summary(
     edges: VesicleEdges,
     status: str,
     error: str = "",
+    radius_result: RadiusDeviationResult | None = None,
 ) -> dict:
     """Build a summary row for one QCed checkpoint."""
     successful = edges.successful_detections
@@ -349,13 +395,19 @@ def _qc_summary(
         QCFlag.CURVATURE in detection.qc.flags
         for detection in successful
     )
-    accepted = sum(detection.qc.passed for detection in successful)
+    curvature_accepted = sum(detection.qc.passed for detection in successful)
+    radius_rejected = 0 if radius_result is None else radius_result.rejected_count
+    accepted = curvature_accepted - radius_rejected
     return {
         "file": str(_relative_input_path(path, input_path)),
         "frames": len(edges.detections),
         "successful_detections": len(successful),
         "extraction_failures": len(edges.detections) - len(successful),
         "curvature_rejected": curvature_rejected,
+        "radius_deviation_rejected": radius_rejected,
+        "radius_reference_pixels": (
+            "" if radius_result is None else radius_result.reference_radius_pixels
+        ),
         "accepted": accepted,
         "accepted_fraction": accepted / len(successful),
         "status": status,
@@ -371,6 +423,8 @@ def _load_error_summary(path: Path, input_path: Path, error: str) -> dict:
         "successful_detections": 0,
         "extraction_failures": 0,
         "curvature_rejected": 0,
+        "radius_deviation_rejected": 0,
+        "radius_reference_pixels": "",
         "accepted": 0,
         "accepted_fraction": 0.0,
         "status": "load_error",
@@ -382,6 +436,7 @@ def process_qc_file(
     path: Path,
     args: argparse.Namespace,
     qc_config: EdgeQCConfig,
+    radius_config: RadiusDeviationConfig | None = None,
 ) -> dict:
     """Apply QC to one checkpoint and return its batch summary row."""
     output_path = (
@@ -413,13 +468,49 @@ def process_qc_file(
             status = "no_accepted_frames"
             print(f"QC produced no accepted frames for {path.name}: {error}")
 
-    row = _qc_summary(path, args.input_path, edges, status, qc_error)
+    radius_result = None
+    if status == "ok" and radius_config is not None:
+        try:
+            radius_result = screen_radius_deviations(
+                edges.accepted_detections,
+                radius_config,
+            )
+            if radius_result.accepted_count == 0:
+                status = "no_accepted_frames"
+                qc_error = "Experimental radius-deviation QC accepted no frames."
+        except ValueError as error:
+            status = "experimental_qc_error"
+            qc_error = str(error)
+            print(f"Experimental QC failed for {path.name}: {error}")
+
+    row = _qc_summary(
+        path,
+        args.input_path,
+        edges,
+        status,
+        qc_error,
+        radius_result,
+    )
     if (
         status == "ok"
         and row["accepted"] > 0
         and (args.overwrite or not output_exists)
     ):
-        edges.save_edge_to_npy(output_path)
+        if radius_result is None:
+            edges.save_edge_to_npy(output_path)
+        else:
+            accepted_radii = edges.accepted_radii_microns[
+                list(radius_result.accepted_positions)
+            ]
+            np.save(output_path, accepted_radii)
+
+    if radius_result is not None:
+        diagnostics_path = output_path.with_suffix(".radius_deviation.json")
+        if args.overwrite or not diagnostics_path.exists():
+            diagnostics_path.write_text(
+                json.dumps(radius_result.to_dict(), indent=2) + "\n",
+                encoding="utf-8",
+            )
     return row
 
 
@@ -432,6 +523,8 @@ def _write_qc_summary(output_dir: Path, rows: list[dict]) -> None:
         "successful_detections",
         "extraction_failures",
         "curvature_rejected",
+        "radius_deviation_rejected",
+        "radius_reference_pixels",
         "accepted",
         "accepted_fraction",
         "status",
@@ -460,6 +553,7 @@ def _run_qc(args: argparse.Namespace) -> None:
         raise FileNotFoundError(f"No .npz files found in {args.input_path}")
 
     qc_config = _qc_config_from_args(args)
+    radius_config = _radius_deviation_config_from_args(args)
     _write_qc_provenance(
         args.output_dir,
         qc_config,
@@ -467,9 +561,10 @@ def _run_qc(args: argparse.Namespace) -> None:
         args.recursive,
         paths,
         args.overwrite,
+        radius_config,
     )
     rows = [
-        process_qc_file(path, args, qc_config)
+        process_qc_file(path, args, qc_config, radius_config)
         for path in paths
     ]
     _write_qc_summary(args.output_dir, rows)

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -157,7 +157,7 @@ def _add_qc_parser(subparsers) -> None:
         help="Disable frame-level curvature QC.",
     )
     parser.add_argument(
-        "--experimental-radius-deviation-threshold",
+        "--radius-deviation-threshold",
         type=float,
         default=None,
         help=(
@@ -302,7 +302,7 @@ def _radius_deviation_config_from_args(
     """Build the optional experimental radius-screen configuration."""
     threshold = getattr(
         args,
-        "experimental_radius_deviation_threshold",
+        "radius_deviation_threshold",
         None,
     )
     if threshold is None:


### PR DESCRIPTION
Closes #86

## Description

VesEdge previously had no automatic replacement for the removed GMM population QC when the edge detector switched from the intended vesicle to a substantially different-sized dust particle. This PR adds a deliberately simple, opt-in experimental screen based only on radius.

After ordinary curvature QC, the screen:

1. calculates the median contour radius for every curvature-accepted frame;
2. uses the trajectory-wide median of those frame radii as the reference;
3. calculates `abs(frame_radius - reference_radius) / reference_radius`;
4. rejects frames whose relative deviation is greater than the explicitly supplied threshold.

Using the trajectory median makes the decision independent of when the detector switches objects, so dust at the beginning is handled the same way as dust in the middle or end.

The implementation lives under `vesmod.VesEdge.experimental`. It does not add experimental fields to `EdgeQCConfig`, mutate core QC flags, or change `VesicleQCResult`.

Important limitations:

- the intended vesicle must occupy more than half of the curvature-accepted frames;
- the wrong object must have a materially different radius;
- this is not a population model and does not distinguish genuine vesicle states;
- no universal cutoff is assumed, so the feature is disabled unless the user supplies one.

## Usage Changes

Enable the experimental screen as part of the existing VesEdge QC workflow:

```bash
vesedge qc ./checkpoints \
    --curvature-threshold 5 \
    --radius-deviation-threshold 0.2 \
    --output-dir ./results/qc_radius_screen
```

Here, `0.2` permits a 20% difference from the trajectory-wide median radius. Omitting the option preserves the curvature-only behavior.

When enabled:

- exported `.npy` files contain frames accepted by both curvature QC and the experimental radius screen;
- `vesedge_qc.json` records the setting under a separate `experimental.radius_deviation` section;
- `qc_summary.csv` reports `radius_deviation_rejected` and `radius_reference_pixels`;
- each processed checkpoint produces `<sample>.radius_deviation.json` with the reference radius and per-frame radius, deviation, and decision.

Python users can call:

```python
from vesmod.VesEdge.experimental import (
    RadiusDeviationConfig,
    screen_radius_deviations,
)

result = screen_radius_deviations(
    edges.accepted_detections,
    RadiusDeviationConfig(max_relative_deviation=0.2),
)
```

The returned positions correspond to `edges.accepted_detections`; the function does not modify the stable QC result.

## Todos

- [x] Add the experimental configuration, per-frame diagnostics, and aggregate result models
- [x] Apply the radius screen after curvature QC without changing core QC state
- [x] Filter exported contours using the experimental decisions
- [x] Record configuration, per-frame diagnostics, and batch-summary counts
- [x] Cover dust occurring at the beginning of a trajectory
- [x] Cover an Acquisition-8-sized gradual radius change
- [x] Document CLI usage, assumptions, outputs, and Python API
- [x] Run syntax compilation and repository diff checks
- [ ] Confirm the full pytest suite and pylint checks in CI

## Pre-Review checklist (PR maker)

- [x] New or changed public functions are documented
- [x] User-facing changes are documented above
- [ ] Relevant tests pass
- [x] Notebook changes are complete or marked not applicable — no notebooks changed

## Review checklist (Reviewer)

- [ ] New or changed public functions are documented
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] Relevant tests pass
- [ ] Notebooks still function correctly or are not affected

## Status

- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in experimental median-radius quality screen to the VesEdge QC command.
  - QC summaries and provenance now include radius-deviation metrics and configuration.
  - Added per-file diagnostic JSON output and filtered radius results.
  - Added a standalone API for running radius-deviation screening without changing stable QC state.

- **Documentation**
  - Documented configuration, thresholds, diagnostics, assumptions, CLI usage, and generated outputs.

- **Bug Fixes**
  - Overwriting QC results now removes stale radius diagnostic files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->