### PR TITLE
94 support multiple and globbed cli inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Extract each microscopy video once and keep the resulting checkpoint. QC can the
 ### 1. Extract videos to checkpoints
 
 ```bash
-vesedge extract ./videos \
+vesedge extract "./videos" \
     --pixels-per-micron 13.44 \
     --downsample \
     --n-samples 120 \
@@ -114,7 +114,7 @@ The checkpoint contains extraction state only. It does not store QC decisions.
 Use a dedicated output directory for each QC configuration:
 
 ```bash
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --curvature-threshold 5 \
     --output-dir ./results/qc_standard
 ```
@@ -140,7 +140,7 @@ results/qc_standard/
 For example:
 
 ```bash
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --curvature-threshold 10 \
     --output-dir ./results/qc_permissive
 ```
@@ -154,14 +154,14 @@ Do not store unrelated `.npy` files in a QC output directory: an incompatible re
 The default EdgeMod CLI uses the historical fixed q range, q = 3–7:
 
 ```bash
-edgemod ./results/qc_standard
-edgemod ./results/qc_permissive
+edgemod "./results/qc_standard"
+edgemod "./results/qc_permissive"
 ```
 
 Experimental dynamic q-range selection can be enabled explicitly. The selector runs before the stable physical fitter, searches only inside the configured candidate interval, and requires explicit acceptance thresholds:
 
 ```bash
-edgemod ./results/qc_standard \
+edgemod "./results/qc_standard" \
     --dynamic-range \
     --lower-fitting-bound 3 \
     --upper-fitting-bound 20 \

--- a/docs/EdgeMod_CLI_README.md
+++ b/docs/EdgeMod_CLI_README.md
@@ -35,7 +35,7 @@ Experimental features:
 Fit one contour trajectory using the stable historical defaults:
 
 ```bash
-edgemod sample.npy
+edgemod "sample.npy"
 ```
 
 Defaults:
@@ -59,8 +59,8 @@ If physical-fit validation fails after HSS97 fitting is attempted, EdgeMod write
 For a VesEdge batch:
 
 ```bash
-vesedge qc ./checkpoints --output-dir ./results/qc_standard
-edgemod ./results/qc_standard
+vesedge qc "./checkpoints" --output-dir ./results/qc_standard
+edgemod "./results/qc_standard"
 ```
 
 ---
@@ -82,7 +82,7 @@ Distances should be in microns. `vesedge qc` output is directly suitable for Edg
 Fixed fitting is the default and is the stable EdgeMod behavior.
 
 ```bash
-edgemod sample.npy \
+edgemod "sample.npy" \
     --lower-fitting-bound 3 \
     --upper-fitting-bound 8
 ```
@@ -134,7 +134,7 @@ The selector searches only within the interval defined by `--lower-fitting-bound
 Example:
 
 ```bash
-edgemod sample.npy \
+edgemod "sample.npy" \
     --dynamic-range \
     --lower-fitting-bound 3 \
     --upper-fitting-bound 20 \
@@ -178,18 +178,18 @@ edgemod experimental --help
 Measure every selected trajectory without excluding any input:
 
 ```bash
-edgemod experimental temporal-rms ./results/qc_standard \
+edgemod experimental temporal-rms "./results/qc_standard" \
     --output-dir ./results/rms_report
 ```
 
 Apply an explicitly chosen cutoff and export only accepted trajectories:
 
 ```bash
-edgemod experimental temporal-rms ./results/qc_standard \
+edgemod experimental temporal-rms "./results/qc_standard" \
     --output-dir ./results/rms_50nm \
     --cutoff-nm 50
 
-edgemod ./results/rms_50nm
+edgemod "./results/rms_50nm"
 ```
 
 The stage removes each Fourier mode's temporal mean before combining its power,
@@ -346,23 +346,51 @@ The dependency direction is therefore experimental selection -> fixed q bounds -
 
 ## File Selection and Batch Behavior
 
+Always double-quote each input path or pattern. Quoting ordinary paths is safe,
+handles spaces, and prevents the shell from expanding wildcard patterns before
+EdgeMod receives them. This lets EdgeMod apply suffix validation, deduplication,
+and `--recursive` consistently. Double quotes also allow shell variables such as
+`"$DATA_DIR/*.npy"` to expand while preserving the wildcard for EdgeMod.
+
 Single file:
 
 ```bash
-edgemod sample.npy
+edgemod "sample.npy"
 ```
 
 Directory:
 
 ```bash
-edgemod ./edges
+edgemod "./edges"
+```
+
+Multiple selectors:
+
+```bash
+edgemod "./condition_a/sample.npy" "./condition_b/sample.npy"
+```
+
+Wildcard pattern:
+
+```bash
+edgemod "./conditions/*/sample.npy"
 ```
 
 Recursive directory search:
 
 ```bash
-edgemod ./edges --recursive
+edgemod "./edges" --recursive
 ```
+
+Recursive wildcard search:
+
+```bash
+edgemod "./conditions/*" --recursive
+```
+
+Do not remove the quotes from wildcard examples. An unquoted wildcard may be
+expanded by the shell first, changing which selectors EdgeMod sees and how
+recursive discovery behaves.
 
 Recursive runs report expected fitting/numerical failures and continue with later spectra. Direct non-recursive runs propagate those failures to the caller.
 

--- a/docs/VesEdge_CLI_README.md
+++ b/docs/VesEdge_CLI_README.md
@@ -23,7 +23,7 @@ This allows expensive image processing to be run once while QC settings are eval
 Extract a directory of ND2 videos:
 
 ```bash
-vesedge extract ./videos \
+vesedge extract "./videos" \
     --pixels-per-micron 13.44 \
     --downsample \
     --n-samples 120 \
@@ -33,7 +33,7 @@ vesedge extract ./videos \
 Apply one QC configuration:
 
 ```bash
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --curvature-threshold 5 \
     --max-relative-area-deviation 0.25 \
     --output-dir ./results/qc_standard
@@ -42,7 +42,7 @@ vesedge qc ./checkpoints \
 Analyze the filtered results:
 
 ```bash
-edgemod ./results/qc_standard
+edgemod "./results/qc_standard"
 ```
 
 ---
@@ -53,23 +53,40 @@ edgemod ./results/qc_standard
 
 ## Input Selection
 
+Always double-quote each input path or pattern. Quoting ordinary paths is safe,
+handles spaces, and prevents the shell from expanding wildcard patterns before
+VesEdge receives them. This lets VesEdge apply suffix validation,
+deduplication, and `--recursive` consistently. Double quotes also allow shell
+variables such as `"$DATA_DIR/*.nd2"` to expand while preserving the wildcard
+for VesEdge.
+
 Extract one video:
 
 ```bash
-vesedge extract sample.nd2
+vesedge extract "sample.nd2"
 ```
 
 Extract all ND2 files in a directory:
 
 ```bash
-vesedge extract ./videos
+vesedge extract "./videos"
 ```
 
 Search recursively:
 
 ```bash
-vesedge extract ./videos --recursive
+vesedge extract "./videos" --recursive
 ```
+
+Select multiple files or patterns by listing each selector separately:
+
+```bash
+vesedge extract "./condition_a/*.nd2" "./condition_b/*.nd2" --recursive
+```
+
+Do not remove the quotes from wildcard examples. An unquoted wildcard may be
+expanded by the shell first, changing which selectors VesEdge sees and how
+recursive discovery behaves.
 
 Directory discovery treats file suffixes case-insensitively, so `.nd2` and `.ND2` inputs are handled consistently.
 
@@ -80,7 +97,7 @@ By default, `.npz` and GIF outputs are written beside each ND2 input.
 Use a dedicated checkpoint directory with:
 
 ```bash
-vesedge extract ./videos --output-dir ./checkpoints
+vesedge extract "./videos" --output-dir ./checkpoints
 ```
 
 For a file named `sample.nd2`, extraction normally produces:
@@ -99,19 +116,19 @@ The GIF overlays the extracted full contour on the original image frames for vis
 Disable GIF creation with:
 
 ```bash
-vesedge extract sample.nd2 --no-gif
+vesedge extract "sample.nd2" --no-gif
 ```
 
 Existing checkpoints are not overwritten unless:
 
 ```bash
-vesedge extract sample.nd2 --overwrite
+vesedge extract "sample.nd2" --overwrite
 ```
 
 ## Microscope Calibration
 
 ```bash
-vesedge extract sample.nd2 --pixels-per-micron 13.44
+vesedge extract "sample.nd2" --pixels-per-micron 13.44
 ```
 
 `--pixels-per-micron` stores the microscope calibration in the checkpoint. Accepted contours are converted from pixels to microns later, when QC output is exported to `.npy`.
@@ -123,7 +140,7 @@ Default: `1.0`.
 Use fixed angular sampling with:
 
 ```bash
-vesedge extract sample.nd2 --downsample --n-samples 120
+vesedge extract "sample.nd2" --downsample --n-samples 120
 ```
 
 `--n-samples` defaults to `120` and is used only when `--downsample` is provided.
@@ -141,14 +158,14 @@ vesmod.VesEdge:extract_edge_from_frame
 Use an importable custom extractor with:
 
 ```bash
-vesedge extract sample.nd2 \
+vesedge extract "sample.nd2" \
     --extractor my_package.my_module:my_edge_extractor
 ```
 
 or a Python source file with:
 
 ```bash
-vesedge extract sample.nd2 \
+vesedge extract "sample.nd2" \
     --extractor-file ./my_extractor.py \
     --extractor-name my_edge_extractor
 ```
@@ -164,29 +181,40 @@ See the [custom extractor guide](custom_edge_extraction_algorithms.README.md) fo
 The command requires an output directory:
 
 ```bash
-vesedge qc ./checkpoints --output-dir ./results/qc_standard
+vesedge qc "./checkpoints" --output-dir ./results/qc_standard
 ```
 
 Use a **different output directory for each QC configuration**. This keeps the `.npy` data, exact QC settings, resolved checkpoint selection, and QC summary together as one reproducible analysis condition.
 
 ## Input Selection
 
+As with extraction, always double-quote every checkpoint path or pattern so
+VesEdge—not the shell—performs wildcard expansion and recursive discovery.
+
 QC one checkpoint:
 
 ```bash
-vesedge qc sample.npz --output-dir ./results/qc_standard
+vesedge qc "sample.npz" --output-dir ./results/qc_standard
 ```
 
 QC all checkpoints in a directory:
 
 ```bash
-vesedge qc ./checkpoints --output-dir ./results/qc_standard
+vesedge qc "./checkpoints" --output-dir ./results/qc_standard
 ```
 
 Search recursively with:
 
 ```bash
-vesedge qc ./checkpoints --recursive --output-dir ./results/qc_standard
+vesedge qc "./checkpoints" --recursive --output-dir ./results/qc_standard
+```
+
+QC multiple explicit files or wildcard patterns:
+
+```bash
+vesedge qc "./condition_a/*.npz" "./condition_b/*.npz" \
+    --recursive \
+    --output-dir ./results/qc_standard
 ```
 
 Directory discovery treats `.npz` suffixes case-insensitively. For recursive directory inputs, output `.npy` files preserve the checkpoint paths relative to the selected checkpoint directory, preventing equal filenames in different subdirectories from colliding.
@@ -194,7 +222,7 @@ Directory discovery treats `.npz` suffixes case-insensitively. For recursive dir
 ## Curvature QC
 
 ```bash
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --curvature-threshold 5 \
     --output-dir ./results/qc_standard
 ```
@@ -206,7 +234,7 @@ Default: `5.0`.
 Disable curvature QC with:
 
 ```bash
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --no-curvature-qc \
     --output-dir ./results/no_curvature
 ```
@@ -230,7 +258,7 @@ Using `mean(r**2)` retains noncircular contour variation and differs from approx
 Set the largest accepted fractional deviation with:
 
 ```bash
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --max-relative-area-deviation 0.25 \
     --output-dir ./results/qc_standard
 ```
@@ -240,7 +268,7 @@ Default: `0.25`. A deviation exactly equal to the threshold passes; a larger dev
 Disable this rule with:
 
 ```bash
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --no-area-qc \
     --output-dir ./results/no_area_qc
 ```
@@ -253,7 +281,7 @@ The trajectory median assumes that most successful detections trace the correct 
 For checkpoints `sample01.npz` and `sample02.npz`, the command:
 
 ```bash
-vesedge qc ./checkpoints --output-dir ./results/qc_standard
+vesedge qc "./checkpoints" --output-dir ./results/qc_standard
 ```
 
 normally creates:
@@ -319,15 +347,15 @@ Use a dedicated QC output directory. For an incompatible overwrite, VesEdge recu
 A typical sensitivity analysis might use:
 
 ```bash
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --curvature-threshold 5 \
     --output-dir ./results/qc_strict
 
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --curvature-threshold 10 \
     --output-dir ./results/qc_standard
 
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --curvature-threshold 15 \
     --output-dir ./results/qc_permissive
 ```
@@ -335,9 +363,9 @@ vesedge qc ./checkpoints \
 Then run:
 
 ```bash
-edgemod ./results/qc_strict
-edgemod ./results/qc_standard
-edgemod ./results/qc_permissive
+edgemod "./results/qc_strict"
+edgemod "./results/qc_standard"
+edgemod "./results/qc_permissive"
 ```
 
 The resulting EdgeMod estimates can be reported alongside each directory's `vesedge_qc.json` and `qc_summary.csv` to show whether the scientific conclusion depends strongly on QC choices.
@@ -351,14 +379,14 @@ The resulting EdgeMod estimates can be reported alongside each directory's `vese
 Run one checkpoint:
 
 ```bash
-vesedge internal-structures sample.npz \
+vesedge internal-structures "sample.npz" \
     --output-dir ./results/internal_structures
 ```
 
 Run a recursive checkpoint collection:
 
 ```bash
-vesedge internal-structures ./checkpoints \
+vesedge internal-structures "./checkpoints" \
     --recursive \
     --output-dir ./results/internal_structures
 ```
@@ -372,7 +400,7 @@ Normal use requires `--qc-results` pointing to a QC output directory or directly
 To evaluate the experimental detector before choosing QC, explicitly request all successful edge detections:
 
 ```bash
-vesedge internal-structures ./checkpoints \
+vesedge internal-structures "./checkpoints" \
     --include-unqced \
     --output-dir ./results/internal_structures_unqced
 ```
@@ -382,7 +410,7 @@ Exactly one of `--qc-results` and `--include-unqced` is required. The analysis r
 ## Experimental Parameters
 
 ```bash
-vesedge internal-structures ./checkpoints \
+vesedge internal-structures "./checkpoints" \
     --output-dir ./results/internal_structures \
     --membrane-exclusion-px 5 \
     --background-sigma-px 30 \
@@ -411,7 +439,7 @@ These defaults are starting values, not calibrated population boundaries. Compar
 The checkpoint records the original ND2 path. If videos have moved, place them in one directory and supply:
 
 ```bash
-vesedge internal-structures ./checkpoints \
+vesedge internal-structures "./checkpoints" \
     --video-root /new/video/location \
     --output-dir ./results/internal_structures
 ```

--- a/docs/VesEdge_GIF_CLI.md
+++ b/docs/VesEdge_GIF_CLI.md
@@ -6,6 +6,10 @@ edge extraction.
 
 ## Render recursively
 
+Always double-quote each checkpoint path or pattern. This is safe for ordinary
+paths and ensures that VesEdge, rather than the shell, expands wildcard
+patterns and applies `--recursive`.
+
 Given extraction checkpoints under `checkpoints/`:
 
 ```text
@@ -17,7 +21,7 @@ checkpoints/
 the following command mirrors that structure under `gifs/`:
 
 ```bash
-vesedge gif checkpoints/ --recursive --output-dir gifs/ --style edges
+vesedge gif "checkpoints/" --recursive --output-dir gifs/ --style edges
 ```
 
 ## Available styles
@@ -25,7 +29,7 @@ vesedge gif checkpoints/ --recursive --output-dir gifs/ --style edges
 Render the source video without annotations:
 
 ```bash
-vesedge gif checkpoints/ \
+vesedge gif "checkpoints/" \
     --recursive \
     --output-dir gifs/original/ \
     --style original
@@ -34,7 +38,7 @@ vesedge gif checkpoints/ \
 Render all successfully detected edges in green:
 
 ```bash
-vesedge gif checkpoints/ \
+vesedge gif "checkpoints/" \
     --recursive \
     --output-dir gifs/edges/ \
     --style edges
@@ -43,7 +47,7 @@ vesedge gif checkpoints/ \
 Render accepted edges in green and QC-rejected edges in red:
 
 ```bash
-vesedge gif checkpoints/ \
+vesedge gif "checkpoints/" \
     --recursive \
     --output-dir gifs/qc/ \
     --style qc \
@@ -77,7 +81,7 @@ recursive batch, that failure does not stop other checkpoints from rendering.
 Existing GIFs are skipped by default. Replace them with:
 
 ```bash
-vesedge gif checkpoints/ \
+vesedge gif "checkpoints/" \
     --recursive \
     --output-dir gifs/ \
     --style edges \

--- a/docs/custom_edge_extraction_algorithms.README.md
+++ b/docs/custom_edge_extraction_algorithms.README.md
@@ -99,7 +99,7 @@ def constant_radius_extractor(frame):
 Run it during the extraction stage:
 
 ```bash
-vesedge extract sample.nd2 \
+vesedge extract "sample.nd2" \
     --extractor-file ./constant_radius_extractor.py \
     --extractor-name constant_radius_extractor
 ```
@@ -113,7 +113,7 @@ This writes a QC-independent `.npz` checkpoint. Apply QC later with `vesedge qc`
 Use `--extractor` with `module:function` syntax:
 
 ```bash
-vesedge extract sample.nd2 \
+vesedge extract "sample.nd2" \
     --extractor my_package.my_module:my_edge_extractor
 ```
 
@@ -151,12 +151,12 @@ Quality-control outcomes are **not** extraction failures. `VesicleVideo.extract_
 For example:
 
 ```bash
-vesedge extract sample.nd2 \
+vesedge extract "sample.nd2" \
     --extractor-file ./my_extractor.py \
     --extractor-name my_edge_extractor \
     --output-dir ./checkpoints
 
-vesedge qc ./checkpoints \
+vesedge qc "./checkpoints" \
     --curvature-threshold 10 \
     --output-dir ./results/qc_standard
 ```

--- a/tests/unit_tests/test_cli_input_selection.py
+++ b/tests/unit_tests/test_cli_input_selection.py
@@ -1,0 +1,145 @@
+"""Tests for shared multi-path and glob CLI input selection."""
+
+from pathlib import Path
+import sys
+
+from vesmod.cli import edgemod_cli, vesedge_cli
+from vesmod.cli.input_selection import select_input_files
+
+
+def test_select_input_files_accepts_multiple_explicit_files(tmp_path):
+    """Shell-expanded globs can arrive as multiple explicit positional files."""
+    first = tmp_path / "a.npz"
+    second = tmp_path / "b.npz"
+    first.touch()
+    second.touch()
+
+    paths, root = select_input_files([first, second], ".npz", recursive=False)
+
+    assert paths == [first.resolve(), second.resolve()]
+    assert root == tmp_path.resolve()
+
+
+def test_select_input_files_matches_unexpanded_glob(tmp_path):
+    """A quoted glob pattern is expanded by the CLI when the shell does not."""
+    keep = tmp_path / "sample_a.npz"
+    reject = tmp_path / "other.npz"
+    keep.touch()
+    reject.touch()
+
+    paths, root = select_input_files(
+        tmp_path / "sample*.npz",
+        ".npz",
+        recursive=False,
+    )
+
+    assert paths == [keep.resolve()]
+    assert root == tmp_path.resolve()
+
+
+def test_select_input_files_matches_glob_recursively(tmp_path):
+    """--recursive extends a filename glob through subdirectories."""
+    top = tmp_path / "sample_top.npz"
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    nested = nested_dir / "sample_nested.npz"
+    reject = nested_dir / "other.npz"
+    for path in (top, nested, reject):
+        path.touch()
+
+    paths, root = select_input_files(
+        tmp_path / "sample*.npz",
+        ".npz",
+        recursive=True,
+    )
+
+    assert paths == [nested.resolve(), top.resolve()]
+    assert root == tmp_path.resolve()
+
+
+def test_select_input_files_deduplicates_mixed_selectors(tmp_path):
+    """Overlapping explicit and glob selectors produce each file only once."""
+    path = tmp_path / "sample.npz"
+    path.touch()
+
+    paths, _ = select_input_files(
+        [path, tmp_path / "sample*.npz"],
+        ".npz",
+        recursive=False,
+    )
+
+    assert paths == [path.resolve()]
+
+
+def test_vesedge_qc_parser_accepts_multiple_inputs(monkeypatch, tmp_path):
+    """VesEdge QC accepts shell-expanded multiple positional checkpoints."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vesedge",
+            "qc",
+            "a.npz",
+            "b.npz",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    args = vesedge_cli.parse_args()
+
+    assert args.input_path == [Path("a.npz"), Path("b.npz")]
+
+
+def test_vesedge_internal_structures_parser_accepts_multiple_inputs(
+    monkeypatch,
+    tmp_path,
+):
+    """Internal-structures accepts multiple positional checkpoint selectors."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vesedge",
+            "internal-structures",
+            "a.npz",
+            "b.npz",
+            "--output-dir",
+            str(tmp_path),
+            "--include-unqced",
+        ],
+    )
+
+    args = vesedge_cli.parse_args()
+
+    assert args.input_path == Path("a.npz")
+    assert args.additional_input_paths == [Path("b.npz")]
+
+
+def test_vesedge_gif_parser_accepts_multiple_inputs(monkeypatch, tmp_path):
+    """GIF generation accepts shell-expanded multiple positional checkpoints."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vesedge",
+            "gif",
+            "a.npz",
+            "b.npz",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    args = vesedge_cli.parse_args()
+
+    assert args.input_path == [Path("a.npz"), Path("b.npz")]
+
+
+def test_edgemod_parser_accepts_multiple_inputs(monkeypatch):
+    """Core EdgeMod accepts shell-expanded multiple positional arrays."""
+    monkeypatch.setattr(sys, "argv", ["edgemod", "a.npy", "b.npy"])
+
+    args = edgemod_cli.parse_args()
+
+    assert args.input_path == [Path("a.npy"), Path("b.npy")]

--- a/tests/unit_tests/test_edgemod_cli.py
+++ b/tests/unit_tests/test_edgemod_cli.py
@@ -169,18 +169,14 @@ def test_recursive_run_skips_failed_fit_and_continues(
     """Test one failed spectrum does not abort a recursive batch."""
     failed_path = tmp_path / "failed.npy"
     successful_path = tmp_path / "successful.npy"
+    failed_path.touch()
+    successful_path.touch()
     args = _args()
     args.input_path = tmp_path
     args.recursive = True
     processed = []
 
     monkeypatch.setattr(edgemod_cli, "parse_args", lambda: args)
-    monkeypatch.setattr(
-        edgemod_cli,
-        "iter_npy_files",
-        lambda input_path, recursive: [failed_path, successful_path],
-    )
-
     def fake_process_file(path, parsed_args):
         processed.append(path)
         if path == failed_path:
@@ -197,16 +193,12 @@ def test_recursive_run_skips_failed_fit_and_continues(
 def test_nonrecursive_run_propagates_failed_fit(monkeypatch, tmp_path):
     """Test a direct single-spectrum run still reports failure to the caller."""
     failed_path = tmp_path / "failed.npy"
+    failed_path.touch()
     args = _args()
     args.input_path = failed_path
     args.recursive = False
 
     monkeypatch.setattr(edgemod_cli, "parse_args", lambda: args)
-    monkeypatch.setattr(
-        edgemod_cli,
-        "iter_npy_files",
-        lambda input_path, recursive: [failed_path],
-    )
     monkeypatch.setattr(
         edgemod_cli,
         "process_file",

--- a/vesmod/cli/edgemod_cli.py
+++ b/vesmod/cli/edgemod_cli.py
@@ -29,6 +29,8 @@ from vesmod.EdgeMod.experimental.temporal_rms_plotting import (
     save_temporal_rms_histogram,
 )
 
+from .input_selection import InputPathsAction, select_input_files
+
 
 def parse_args() -> argparse.Namespace:
     """Parse the core CLI or an explicitly namespaced experimental command."""
@@ -69,12 +71,14 @@ def _add_input_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "input_path",
         type=Path,
-        help="A .npy file or a directory containing .npy files.",
+        nargs="+",
+        action=InputPathsAction,
+        help="One or more .npy files, directories, or glob patterns.",
     )
     parser.add_argument(
         "--recursive",
         action="store_true",
-        help="Search subdirectories when input_path is a directory.",
+        help="Search subdirectories for directory and glob inputs.",
     )
 
 
@@ -180,19 +184,10 @@ def _add_temporal_rms_parser(subparsers) -> None:
     )
 
 
-def iter_npy_files(input_path: Path, recursive: bool) -> list[Path]:
-    """Return the input ``.npy`` files selected by a CLI path and recursion flag."""
-    input_path = input_path.expanduser().resolve()
-    if input_path.is_file():
-        if input_path.suffix != ".npy":
-            raise ValueError(f"Expected a .npy file, got: {input_path}")
-        return [input_path]
-
-    if not input_path.is_dir():
-        raise FileNotFoundError(f"Input path does not exist: {input_path}")
-
-    pattern = "**/*.npy" if recursive else "*.npy"
-    return sorted(input_path.glob(pattern))
+def iter_npy_files(input_path: Path | list[Path], recursive: bool) -> list[Path]:
+    """Return the input ``.npy`` files selected by CLI selectors."""
+    paths, _ = select_input_files(input_path, ".npy", recursive)
+    return paths
 
 
 def build_fit_config(args: argparse.Namespace) -> SpectrumFitConfig:
@@ -538,9 +533,10 @@ def _run_fit(args: argparse.Namespace) -> None:
     if args.dynamic_range:
         build_dynamic_selector(args)
 
-    paths = iter_npy_files(args.input_path, args.recursive)
+    paths, input_root = select_input_files(args.input_path, ".npy", args.recursive)
     if not paths:
-        raise FileNotFoundError(f"No .npy files found in {args.input_path}")
+        raise FileNotFoundError(f"No .npy files found for {args.input_path}")
+    args.input_path = input_root
 
     for path in paths:
         try:
@@ -553,10 +549,11 @@ def _run_fit(args: argparse.Namespace) -> None:
 
 def _run_temporal_rms(args: argparse.Namespace) -> None:
     """Run one experimental temporal-RMS configuration over selected inputs."""
-    _reject_overlapping_temporal_rms_paths(args.input_path, args.output_dir)
-    paths = iter_npy_files(args.input_path, args.recursive)
+    paths, input_root = select_input_files(args.input_path, ".npy", args.recursive)
     if not paths:
-        raise FileNotFoundError(f"No .npy files found in {args.input_path}")
+        raise FileNotFoundError(f"No .npy files found for {args.input_path}")
+    args.input_path = input_root
+    _reject_overlapping_temporal_rms_paths(args.input_path, args.output_dir)
 
     config = build_temporal_rms_config(args)
     _write_temporal_rms_provenance(

--- a/vesmod/cli/gif_cli.py
+++ b/vesmod/cli/gif_cli.py
@@ -11,6 +11,8 @@ import numpy as np
 
 from vesmod.VesEdge import EdgeQCConfig, VesicleEdges, VesicleVideo
 
+from .input_selection import InputPathsAction, select_input_files
+
 
 def add_gif_parser(subparsers) -> None:
     """Add the standalone GIF-generation subcommand."""
@@ -21,7 +23,9 @@ def add_gif_parser(subparsers) -> None:
     parser.add_argument(
         "input_path",
         type=Path,
-        help="A VesEdge .npz checkpoint or directory containing checkpoints.",
+        nargs="+",
+        action=InputPathsAction,
+        help="One or more VesEdge .npz files, directories, or glob patterns.",
     )
     parser.add_argument(
         "--output-dir",
@@ -50,7 +54,7 @@ def add_gif_parser(subparsers) -> None:
     parser.add_argument(
         "--recursive",
         action="store_true",
-        help="Search checkpoint subdirectories and preserve their structure.",
+        help="Search checkpoint subdirectories and recursive glob matches.",
     )
     parser.add_argument(
         "--overwrite",
@@ -59,17 +63,13 @@ def add_gif_parser(subparsers) -> None:
     )
 
 
-def _checkpoint_paths(input_path: Path, recursive: bool) -> list[Path]:
-    """Return checkpoints selected by one file or directory input."""
-    resolved = input_path.expanduser().resolve()
-    if resolved.is_file():
-        if resolved.suffix.lower() != ".npz":
-            raise ValueError(f"Expected a .npz checkpoint, got: {resolved}")
-        return [resolved]
-    if not resolved.is_dir():
-        raise FileNotFoundError(f"Input path does not exist: {resolved}")
-    pattern = "**/*.npz" if recursive else "*.npz"
-    return sorted(path for path in resolved.glob(pattern) if path.is_file())
+def _checkpoint_paths(
+    input_path: Path | list[Path],
+    recursive: bool,
+) -> list[Path]:
+    """Return checkpoints selected by explicit paths, directories, or globs."""
+    checkpoints, _ = select_input_files(input_path, ".npz", recursive)
+    return checkpoints
 
 
 def _relative_checkpoint_path(checkpoint: Path, input_path: Path) -> Path:
@@ -231,11 +231,14 @@ def run_gif(args: argparse.Namespace) -> None:
     if args.style != "qc" and args.qc_dir is not None:
         raise ValueError("--qc-dir may only be used with --style qc.")
 
-    checkpoints = _checkpoint_paths(args.input_path, args.recursive)
+    checkpoints, input_root = select_input_files(
+        args.input_path,
+        ".npz",
+        args.recursive,
+    )
     if not checkpoints:
-        raise FileNotFoundError(
-            f"No .npz checkpoints found in {args.input_path.expanduser().resolve()}"
-        )
+        raise FileNotFoundError(f"No .npz checkpoints found for {args.input_path}")
+    args.input_path = input_root
 
     args.output_dir = args.output_dir.expanduser().resolve()
     qc_config = (

--- a/vesmod/cli/input_selection.py
+++ b/vesmod/cli/input_selection.py
@@ -2,26 +2,39 @@
 
 from __future__ import annotations
 
+import argparse
 import glob
 import os
 from pathlib import Path
 
 
+class InputPathsAction(argparse.Action):
+    """Preserve one-input Path behavior while accepting multiple selectors."""
+
+    def __call__(self, parser, namespace, values, option_string=None) -> None:
+        """Store one Path directly, or multiple Paths as a list."""
+        del parser, option_string
+        setattr(namespace, self.dest, values[0] if len(values) == 1 else values)
+
+
+def normalize_input_paths(input_path: Path | list[Path]) -> list[Path]:
+    """Return one or more parsed selectors as a list."""
+    return input_path if isinstance(input_path, list) else [input_path]
+
+
 def select_input_files(
-    input_paths: list[Path],
+    input_path: Path | list[Path],
     suffix: str,
     recursive: bool,
 ) -> tuple[list[Path], Path]:
     """Resolve CLI selectors to unique files and a stable relative-path root.
 
-    ``input_paths`` may contain explicit files, directories, shell-expanded
-    filenames, or unexpanded glob patterns. With ``recursive=True``, a glob
-    pattern is also matched below subdirectories of its selected parent, so a
-    selector such as ``pattern*.npz`` finds matching files recursively.
+    Selectors may be explicit files, directories, shell-expanded filenames, or
+    unexpanded glob patterns. With ``recursive=True``, a glob pattern is also
+    matched below subdirectories of its selected parent, so a selector such as
+    ``pattern*.npz`` finds matching files recursively.
     """
-    if not input_paths:
-        raise ValueError("At least one input path is required.")
-
+    input_paths = normalize_input_paths(input_path)
     expected_suffix = suffix.lower()
     matches: set[Path] = set()
     roots: list[Path] = []
@@ -79,9 +92,8 @@ def _recursive_glob(pattern: str) -> str:
 def _glob_root(pattern: str) -> Path:
     """Return the non-glob prefix used as the relative-path root."""
     path = Path(pattern)
-    parts = path.parts
     prefix: list[str] = []
-    for part in parts:
+    for part in path.parts:
         if glob.has_magic(part):
             break
         prefix.append(part)
@@ -89,8 +101,6 @@ def _glob_root(pattern: str) -> Path:
     if not prefix:
         return Path.cwd().resolve()
     root = Path(*prefix)
-    if path.is_absolute() and not root.is_absolute():
-        root = Path(path.anchor) / root
     if root.suffix:
         root = root.parent
     return root.expanduser().resolve()

--- a/vesmod/cli/input_selection.py
+++ b/vesmod/cli/input_selection.py
@@ -1,0 +1,96 @@
+"""Shared CLI discovery for explicit, directory, and globbed inputs."""
+
+from __future__ import annotations
+
+import glob
+import os
+from pathlib import Path
+
+
+def select_input_files(
+    input_paths: list[Path],
+    suffix: str,
+    recursive: bool,
+) -> tuple[list[Path], Path]:
+    """Resolve CLI selectors to unique files and a stable relative-path root.
+
+    ``input_paths`` may contain explicit files, directories, shell-expanded
+    filenames, or unexpanded glob patterns. With ``recursive=True``, a glob
+    pattern is also matched below subdirectories of its selected parent, so a
+    selector such as ``pattern*.npz`` finds matching files recursively.
+    """
+    if not input_paths:
+        raise ValueError("At least one input path is required.")
+
+    expected_suffix = suffix.lower()
+    matches: set[Path] = set()
+    roots: list[Path] = []
+    single_explicit_file: Path | None = None
+
+    for selector in input_paths:
+        selector_text = os.path.expanduser(str(selector))
+        if glob.has_magic(selector_text):
+            roots.append(_glob_root(selector_text))
+            pattern = _recursive_glob(selector_text) if recursive else selector_text
+            for match in glob.glob(pattern, recursive=recursive):
+                candidate = Path(match).expanduser().resolve()
+                if candidate.is_file() and candidate.suffix.lower() == expected_suffix:
+                    matches.add(candidate)
+            continue
+
+        resolved = Path(selector_text).resolve()
+        if resolved.is_file():
+            if resolved.suffix.lower() != expected_suffix:
+                raise ValueError(f"Expected a {expected_suffix} file, got: {resolved}")
+            matches.add(resolved)
+            roots.append(resolved.parent)
+            if len(input_paths) == 1:
+                single_explicit_file = resolved
+            continue
+
+        if resolved.is_dir():
+            roots.append(resolved)
+            candidates = resolved.rglob("*") if recursive else resolved.glob("*")
+            matches.update(
+                candidate.resolve()
+                for candidate in candidates
+                if candidate.is_file()
+                and candidate.suffix.lower() == expected_suffix
+            )
+            continue
+
+        raise FileNotFoundError(f"Input path or pattern does not exist: {selector}")
+
+    if single_explicit_file is not None:
+        root = single_explicit_file
+    else:
+        root = Path(os.path.commonpath([str(path) for path in roots])).resolve()
+    return sorted(matches), root
+
+
+def _recursive_glob(pattern: str) -> str:
+    """Insert a recursive directory match before a glob's filename component."""
+    path = Path(pattern)
+    if "**" in path.parts:
+        return pattern
+    return str(path.parent / "**" / path.name)
+
+
+def _glob_root(pattern: str) -> Path:
+    """Return the non-glob prefix used as the relative-path root."""
+    path = Path(pattern)
+    parts = path.parts
+    prefix: list[str] = []
+    for part in parts:
+        if glob.has_magic(part):
+            break
+        prefix.append(part)
+
+    if not prefix:
+        return Path.cwd().resolve()
+    root = Path(*prefix)
+    if path.is_absolute() and not root.is_absolute():
+        root = Path(path.anchor) / root
+    if root.suffix:
+        root = root.parent
+    return root.expanduser().resolve()

--- a/vesmod/cli/internal_structures_batch_cli.py
+++ b/vesmod/cli/internal_structures_batch_cli.py
@@ -1,0 +1,65 @@
+"""Batch-input wrapper for the internal-structures CLI implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import internal_structures_cli
+from .input_selection import select_input_files
+
+
+def add_parser(subparsers) -> None:
+    """Add internal-structures arguments plus additional input selectors."""
+    internal_structures_cli.add_parser(subparsers)
+    parser = subparsers.choices["internal-structures"]
+    parser.add_argument(
+        "additional_input_paths",
+        type=Path,
+        nargs="*",
+        help="Additional .npz files, directories, or glob patterns.",
+    )
+
+
+def run(args) -> None:
+    """Resolve batch selectors and run the existing measurement orchestration."""
+    selectors = [args.input_path, *args.additional_input_paths]
+    paths, input_root = select_input_files(selectors, ".npz", args.recursive)
+    if not paths:
+        raise FileNotFoundError(f"No .npz files found for {selectors}")
+    args.input_path = input_root
+
+    internal_structures_cli._validate_input_output_paths(
+        args.input_path,
+        args.output_dir,
+    )
+    config = internal_structures_cli.config_from_args(args)
+    qc_config, qc_provenance_path = internal_structures_cli._load_qc_selection(
+        args,
+        paths,
+    )
+    internal_structures_cli._write_provenance(
+        args,
+        paths,
+        config,
+        qc_config,
+        qc_provenance_path,
+    )
+    video_index = internal_structures_cli._build_video_filename_index(
+        paths,
+        args.video_root,
+    )
+    summary_rows = [
+        internal_structures_cli.process_checkpoint(
+            path,
+            args,
+            config,
+            qc_config,
+            video_index,
+        )
+        for path in paths
+    ]
+    internal_structures_cli._write_csv(
+        args.output_dir / "internal_structure_summary.csv",
+        summary_rows,
+        internal_structures_cli._SUMMARY_FIELDS,
+    )

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from . import internal_structures_cli
 from .gif_cli import add_gif_parser, run_gif
+from .input_selection import InputPathsAction, select_input_files
 from .path_utils import _display_path, _relative_input_path
 from vesmod.VesEdge import (
     EdgeExtractionConfig,
@@ -51,12 +52,14 @@ def _add_extract_parser(subparsers) -> None:
     parser.add_argument(
         "input_path",
         type=Path,
-        help="An .nd2 file or a directory containing .nd2 files.",
+        nargs="+",
+        action=InputPathsAction,
+        help="One or more .nd2 files, directories, or glob patterns.",
     )
     parser.add_argument(
         "--recursive",
         action="store_true",
-        help="Search subdirectories when input_path is a directory.",
+        help="Search subdirectories for directory and glob inputs.",
     )
     parser.add_argument(
         "--output-dir",
@@ -122,12 +125,14 @@ def _add_qc_parser(subparsers) -> None:
     parser.add_argument(
         "input_path",
         type=Path,
-        help="A VesEdge .npz checkpoint or directory containing checkpoints.",
+        nargs="+",
+        action=InputPathsAction,
+        help="One or more VesEdge .npz files, directories, or glob patterns.",
     )
     parser.add_argument(
         "--recursive",
         action="store_true",
-        help="Search subdirectories when input_path is a directory.",
+        help="Search subdirectories for directory and glob inputs.",
     )
     parser.add_argument(
         "--output-dir",
@@ -174,27 +179,13 @@ def _add_qc_parser(subparsers) -> None:
 
 
 def iter_input_files(
-    input_path: Path,
+    input_path: Path | list[Path],
     suffix: str,
     recursive: bool,
 ) -> list[Path]:
     """Return selected input files with the requested suffix."""
-    input_path = input_path.expanduser().resolve()
-    suffix = suffix.lower()
-    if input_path.is_file():
-        if input_path.suffix.lower() != suffix:
-            raise ValueError(f"Expected a {suffix} file, got: {input_path}")
-        return [input_path]
-
-    if not input_path.is_dir():
-        raise FileNotFoundError(f"Input path does not exist: {input_path}")
-
-    pattern = "**/*" if recursive else "*"
-    return sorted(
-        candidate
-        for candidate in input_path.glob(pattern)
-        if candidate.is_file() and candidate.suffix.lower() == suffix
-    )
+    paths, _ = select_input_files(input_path, suffix, recursive)
+    return paths
 
 
 def load_extractor_from_module(import_string: str):
@@ -556,9 +547,10 @@ def _write_qc_summary(output_dir: Path, rows: list[dict]) -> None:
 
 def _run_extract(args: argparse.Namespace) -> None:
     """Run extraction over the selected ND2 files."""
-    paths = iter_input_files(args.input_path, ".nd2", args.recursive)
+    paths, input_root = select_input_files(args.input_path, ".nd2", args.recursive)
     if not paths:
-        raise FileNotFoundError(f"No .nd2 files found in {args.input_path}")
+        raise FileNotFoundError(f"No .nd2 files found for {args.input_path}")
+    args.input_path = input_root
 
     for path in paths:
         process_extract_file(path, args)
@@ -566,9 +558,10 @@ def _run_extract(args: argparse.Namespace) -> None:
 
 def _run_qc(args: argparse.Namespace) -> None:
     """Run one QC configuration over the selected checkpoints."""
-    paths = iter_input_files(args.input_path, ".npz", args.recursive)
+    paths, input_root = select_input_files(args.input_path, ".npz", args.recursive)
     if not paths:
-        raise FileNotFoundError(f"No .npz files found in {args.input_path}")
+        raise FileNotFoundError(f"No .npz files found for {args.input_path}")
+    args.input_path = input_root
 
     qc_config = _qc_config_from_args(args)
     _write_qc_provenance(

--- a/vesmod/cli/vesedge_cli.py
+++ b/vesmod/cli/vesedge_cli.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 import nd2
 import numpy as np
 
-from . import internal_structures_cli
+from . import internal_structures_batch_cli as internal_structures_cli
 from .gif_cli import add_gif_parser, run_gif
 from .input_selection import InputPathsAction, select_input_files
 from .path_utils import _display_path, _relative_input_path


### PR DESCRIPTION
Closes #94

## Description

VesEdge and EdgeMod previously accepted only one positional input path. As a result, shell-expanded wildcards such as `*.npz` or `*.npy` became multiple positional arguments and were rejected before input discovery began.

This PR adds shared, suffix-aware input selection across the command-line workflows. Selectors may now be:

- one or more explicit files;
- one or more directories;
- shell-expanded wildcard results;
- quoted or escaped glob patterns that reach VesMod unexpanded;
- mixtures of files, directories, and patterns.

Selection is deterministic and deduplicated. Each command still accepts only its expected file type, and existing single-file and single-directory usage remains valid. A common resolved input root is retained so recursively generated outputs preserve relative directory structure when several selectors are combined.

The shared selector is used by:

- `vesedge extract`;
- `vesedge qc`;
- `vesedge gif`;
- `vesedge internal-structures`;
- EdgeMod fixed and dynamic fitting;
- `edgemod experimental temporal-rms`.

For `internal-structures`, a small batch wrapper composes the new selection behavior around the existing measurement implementation instead of duplicating its analysis logic.

## Usage Changes

Multiple explicit inputs are accepted directly:

```bash
vesedge qc sample01.npz sample02.npz \
    --output-dir ./qc
```

Shell-expanded globs work because all resulting filenames are accepted:

```bash
vesedge qc *.npz --output-dir ./qc
edgemod *.npy
```

VesMod can also expand a quoted pattern itself:

```bash
vesedge qc 'ND Acquisition*.npz' \
    --output-dir ./qc
```

To extend a wildcard search into subdirectories, quote or escape the pattern so the shell does not expand it before VesMod receives it:

```bash
vesedge qc 'ND Acquisition*.npz' \
    --recursive \
    --output-dir ./qc
```

The same forms work for EdgeMod:

```bash
edgemod 'qc_*/*.npy' --recursive
```

and for other VesEdge input-taking commands:

```bash
vesedge extract day1/*.nd2 day2/*.nd2 \
    --output-dir ./checkpoints

vesedge gif experiment_a experiment_b/*.npz \
    --output-dir ./gifs

vesedge internal-structures sample01.npz sample02.npz \
    --output-dir ./internal_structures
```

An unquoted wildcard may be expanded by the shell. Those filenames are still accepted, but VesMod cannot reconstruct the original wildcard and therefore cannot extend it recursively. Quote recursive patterns.

Compatibility and error behavior:

- Existing one-file and one-directory commands continue to work.
- Duplicate matches from overlapping selectors are processed once.
- Results are sorted for deterministic batch order.
- File suffix matching remains case-insensitive.
- Explicit nonexistent selectors and explicit files with the wrong suffix still raise errors.
- Empty selections produce the command-specific “no matching files” error.
- Temporal-RMS overlap protection is evaluated against the resolved common input root.

No output data formats or scientific calculations are changed.

## Todos

- [x] Add a shared selector for files, directories, and glob patterns
- [x] Preserve single-input `Path` behavior while accepting multiple positional selectors
- [x] Support recursive matching for unexpanded glob patterns
- [x] Deduplicate and deterministically sort overlapping selections
- [x] Preserve a stable common root for relative output paths
- [x] Integrate selection with VesEdge extraction and QC
- [x] Integrate selection with standalone GIF generation
- [x] Add an internal-structures batch-input wrapper
- [x] Integrate selection with EdgeMod fitting and temporal-RMS analysis
- [x] Add regression coverage for explicit, mixed, duplicate, globbed, and recursive inputs
- [x] Update pre-existing EdgeMod failure tests to use real validated inputs
- [x] Run Python syntax compilation and repository diff checks
- [ ] Confirm the complete pytest and pylint suites in CI

## Pre-Review checklist (PR maker)

- [x] New or changed public functions are documented
- [x] User-facing changes are documented above
- [ ] Relevant tests pass
- [x] Notebook changes are complete or marked not applicable — no notebooks changed

## Review checklist (Reviewer)

- [ ] New or changed public functions are documented
- [ ] New functions/variables are named appropriately
- [ ] No missed "low-hanging fruit" that would substantially aid readability.
- [ ] Any "high-hanging" or "rotten" fruit is added to the issues list.
- [ ] I understand what the changes are doing and how
- [ ] I understand the motivation for this PR (the PR itself is appropriately documented)
- [ ] Relevant tests pass
- [ ] Notebooks still function correctly or are not affected

## Status

- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI workflows now accept multiple files, directories, and glob patterns for input selection.
  * Recursive searches support glob-based matching and automatically remove duplicate files.
  * Added batch processing support for internal-structures inputs.
  * Improved output and provenance path handling for multi-file workflows.

* **Bug Fixes**
  * Clearer errors are provided for missing files, invalid input types, and empty selections.
  * Updated temporal-RMS validation to work correctly with normalized input paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->